### PR TITLE
Fix serialization warning 

### DIFF
--- a/libs/ui/app/workflows/page.tsx
+++ b/libs/ui/app/workflows/page.tsx
@@ -40,7 +40,12 @@ export default async function Workflows({
 
   return (
     <div className="flex h-screen w-full flex-col justify-between space-y-4 overflow-hidden">
-      {checkoutSession && <CheckoutSessionStatus session={checkoutSession} />}
+      {checkoutSession && (
+        <CheckoutSessionStatus
+          // passing json object to the client component
+          session={JSON.parse(JSON.stringify(checkoutSession))}
+        />
+      )}
       <Header profile={profile} />
       <WorkflowCards workflows={workflows} />
     </div>


### PR DESCRIPTION
FIxes the following next.js warning:


```
Warning: Only plain objects can be passed to Client Components from Server Components. Classes or other objects with methods are not supported.
```