### PR TITLE
Fix Azure OpenAI Crash

### DIFF
--- a/libs/superagent/app/agents/langchain.py
+++ b/libs/superagent/app/agents/langchain.py
@@ -156,8 +156,8 @@ class LangchainAgent(AgentBase):
             **(params),
         }
         return {
+            **options,
             "temperature": options.get("temperature", 0.1),
-            "max_tokens": options.get("max_tokens"),
         }
 
     async def _get_llm(self, llm: LLM):


### PR DESCRIPTION
## Summary

Adds missing spread operator for options. This was causing issues when someone tried to use Azure OpenAI, because api_version, deployment_name etc. were not set.