### PR TITLE
Remove HTML mode from Olostep

### DIFF
--- a/libs/superagent/app/models/tools.py
+++ b/libs/superagent/app/models/tools.py
@@ -1,5 +1,5 @@
 from typing import Optional
-from enum import Enum
+
 from pydantic import BaseModel
 
 
@@ -101,15 +101,9 @@ class TavilyInput(BaseModel):
 class ScraperInput(BaseModel):
     url: str
 
- 
-class FormatEnum(str, Enum):
-    markdown = "markdown"
-    html = "html"
-
 
 class AdvancedScraperInput(BaseModel):
     url: str
-    format: Optional[FormatEnum] = FormatEnum.markdown
 
 
 class GoogleSearchInput(BaseModel):

--- a/libs/superagent/app/tools/advanced_scraper.py
+++ b/libs/superagent/app/tools/advanced_scraper.py
@@ -1,6 +1,6 @@
 import asyncio
-import requests
 
+import requests
 from langchain_community.tools import BaseTool
 
 
@@ -9,36 +9,25 @@ class AdvancedScraper(BaseTool):
     description = "useful for quickly and easily extracting content from a webpage (uses a real browser via Olostep)"
     return_direct = False
 
-    def _run(self, url: str, format: str = "markdown") -> str:
-
+    def _run(self, url: str) -> str:
         endpoint = "https://agent.olostep.com/olostep-p2p-incomingAPI"
         headers = {"Authorization": "Bearer " + self.metadata.get("apiKey")}
-
-        saveHtml = format == "html"
-        saveMarkdown = format == "markdown"
-        expandHtml = format == "html"
-        expandMarkdown = format == "markdown"
 
         # for more details look at => https://docs.olostep.com/api-reference/start-agent
         querystring = {
             "url": url,
-            "saveHtml": saveHtml,
-            "saveMarkdown": saveMarkdown,
-            "expandHtml": expandHtml,
-            "expandMarkdown": expandMarkdown,
+            "saveMarkdown": True,
+            "expandMarkdown": True,
             "waitBeforeScraping": 1,
             "fastLane": True,
             "removeCSSselectors": "default",
-            "timeout": 45
+            "timeout": 45,
         }
 
         response = requests.get(endpoint, headers=headers, params=querystring)
-        if format=="markdown":
-            return response.json().get("markdown_content")
-        else:
-            return response.json().get("html_content")
+        return response.json().get("markdown_content")
 
-    async def _arun(self, url: str, format: str = "markdown") -> str:
+    async def _arun(self, url: str) -> str:
         loop = asyncio.get_event_loop()
-        response_text = await loop.run_in_executor(None, self._run, url, format)
+        response_text = await loop.run_in_executor(None, self._run, url)
         return response_text


### PR DESCRIPTION
## Summary

This PR removes HTML mode completely and defaults to markdown format for all the time. This should be done because one of users was experiencing context limit issues. 