### PR TITLE
(Astra DB) add caller library name as User-Agent header in requests to Astra DB

### DIFF
--- a/libs/superagent/app/vectorstores/astra_client.py
+++ b/libs/superagent/app/vectorstores/astra_client.py
@@ -45,6 +45,7 @@ class AstraClient:
         self.request_header = {
             "x-cassandra-token": self.astra_application_token,
             "Content-Type": "application/json",
+            "User-Agent": "superagent",
         }
         self.create_url = f"https://{self.astra_id}-{self.astra_region}.apps.astra.datastax.com/api/json/v1/{self.keyspace_name}"
 


### PR DESCRIPTION
## Summary

This PR adds a custom user-agent header to HTTP requests to the Astra DB data API, for aggregated usage statistics on the server side.

## Test plan

Given how simple the change is, all I did was to manually test there are no glitches in running a simple code using some methods of an instantiated AstraClient class.