### PR TITLE
fix: LLMAgent's call_tool function to correctly serialize arguments

### DIFF
--- a/libs/superagent/app/agents/llm.py
+++ b/libs/superagent/app/agents/llm.py
@@ -55,7 +55,7 @@ async def call_tool(
                 content="",
                 additional_kwargs={
                     "function_call": {
-                        "arguments": args,
+                        "arguments": json.dumps(args),
                         "name": name,
                     }
                 },


### PR DESCRIPTION
## Summary

In Langchain agent we return tool args in a string type, we should do the same in LLMAgent to comply with that.