### PR TITLE
:herb: upgrade CLI version and disable the usage of title field

### DIFF
--- a/fern/apis/prod/generators.yml
+++ b/fern/apis/prod/generators.yml
@@ -1,3 +1,7 @@
+api:
+  path: ./openapi/openapi.yaml
+  settings:
+    use-title: false
 groups:
   publish:
     generators:

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "superagent",
-  "version": "0.16.43"
+  "version": "0.25.0"
 }


### PR DESCRIPTION
## Summary

This is an upgrade to the Fern CLI that allows the Superagent config to continue upgrading by disabling the usage of the title field that was causing schema conflicts.