### PR TITLE
(Astra DB) Explicit projection when reading from Astra DB

### DIFF
--- a/libs/superagent/app/vectorstores/astra_client.py
+++ b/libs/superagent/app/vectorstores/astra_client.py
@@ -160,6 +160,7 @@ class AstraClient:
         query = {
             "sort": {"$vector": vector},
             "options": {"limit": top_k, "includeSimilarity": True},
+            "projection": {"*": 1},
         }
         if filters is not None:
             query["filter"] = filters


### PR DESCRIPTION
## Summary

In view of upcoming changes in the Astra DB Data API, this PR explicitly sets a projection every time a `find` command is executed, in order to ensure all necessary fields of the document are returned by the API.

