### PR TITLE
:herb: bump python generator to latest

### DIFF
--- a/fern/apis/prod/generators.yml
+++ b/fern/apis/prod/generators.yml
@@ -6,7 +6,7 @@ groups:
   publish:
     generators:
       - name: fernapi/fern-python-sdk
-        version: 0.11.9
+        version: 2.2.0
         disable-examples: true
         output:
           location: pypi
@@ -16,6 +16,13 @@ groups:
           repository: homanp/superagent-py
         config:
           client_class_name: Superagent
+          inline_request_params: false
+          improved_imports: false
+          pydantic_config:
+            require_optional_fields: true
+            use_str_enums: false
+            extra_fields: "forbid"
+
       - name: fernapi/fern-typescript-node-sdk
         version: 0.12.5
         output:


### PR DESCRIPTION
## Summary

Note that this brings the python generator to latest which is through 2 major version bumps. The relevant configuration has been implemented to make these changes non-breaking, however it is still recommended to review the output to confirm you are comfortable with the changes.

Changelog: https://github.com/fern-api/fern/blob/main/generators/python/sdk/CHANGELOG.md

Fixes failing CI in https://github.com/superagent-ai/superagent-py

