### PR TITLE
Add request body to logging

### DIFF
--- a/node/src/server.js
+++ b/node/src/server.js
@@ -283,6 +283,19 @@ class ProxyServer {
         // Ignore parsing errors
       }
 
+      // Log request body before structured logging
+      logger.info('Request body received', {
+        event_type: 'request_body',
+        trace_id: traceId,
+        method: req.method,
+        url: req.url,
+        model: extractedModel,
+        body_size_bytes: Buffer.byteLength(requestBody || '', 'utf8'),
+        body: requestBody || null,
+        processed_body: processedRequestBody || null,
+        redaction_occurred: inputRedacted
+      });
+
       // Log structured request data
       logger.logRequest({
         trace_id: traceId,

--- a/rust/src/server.rs
+++ b/rust/src/server.rs
@@ -338,6 +338,20 @@ impl ProxyServer {
                 .header("content-type", "application/json")
                 .body(Body::from(redacted_response))?);
 
+            // Log request body before processing
+            info!(
+                event_type = "request_body",
+                trace_id = %trace_id,
+                method = %parts.method,
+                url = %parts.uri,
+                model = model_name.as_deref().unwrap_or(""),
+                body_size_bytes = request_body.len(),
+                body = %request_body,
+                processed_body = %processed_request_body,
+                redaction_occurred = processed_request_body != request_body,
+                "Request body received"
+            );
+
             // Log the completed request
             let duration = start_time.elapsed();
             let input_redacted = processed_request_body != request_body;
@@ -367,6 +381,20 @@ impl ProxyServer {
 
         // For SSE responses, we'll log after the stream completes
         if is_sse {
+            // Log request body for SSE responses too
+            info!(
+                event_type = "request_body",
+                trace_id = %trace_id,
+                method = %parts.method,
+                url = %parts.uri,
+                model = model_name.as_deref().unwrap_or(""),
+                body_size_bytes = request_body.len(),
+                body = %request_body,
+                processed_body = %processed_request_body,
+                redaction_occurred = processed_request_body != request_body,
+                "Request body received (SSE)"
+            );
+
             let duration = start_time.elapsed();
             let input_redacted = processed_request_body != request_body;
             


### PR DESCRIPTION
## Description
<!-- A brief summary of the changes in this pull request. -->
This pull request adds improved logging of incoming request bodies to both the Node.js and Rust proxy server implementations. The main enhancement is the introduction of structured logs that capture detailed information about every request body, including whether redaction occurred, both for standard and SSE (Server-Sent Events) responses.

**Logging improvements:**

* Added a structured log entry for every incoming request body in `node/src/server.js`, including fields such as `event_type`, `trace_id`, HTTP method, URL, model, body size, raw body, processed body, and redaction status.
* Added a similar structured log entry in `rust/src/server.rs` for standard requests, capturing the same set of fields and logging before processing the request.
* Extended structured request body logging to SSE responses in the Rust server, ensuring request details are logged for streaming endpoints as well.

## Checklist
- [x] I tested my changes
- [x] I reviewed my own code