### PR TITLE
Fix issue with not sending complete json body in webhooks

### DIFF
--- a/node/src/server.js
+++ b/node/src/server.js
@@ -838,7 +838,7 @@ class ProxyServer {
         originalUrl: req.url,
         targetUrl: targetUrl.href,
         headers: this.redactSensitiveContent(JSON.stringify(req.headers)),
-        body: requestBody ? this.redactSensitiveContent(requestBody.substring(0, 10000)) : null,
+        body: requestBody ? this.redactSensitiveContent(requestBody) : null,
         userAgent: req.headers['user-agent'],
         originator: req.headers['originator'],
         contentType: req.headers['content-type'],

--- a/rust/src/server.rs
+++ b/rust/src/server.rs
@@ -680,11 +680,12 @@ impl ProxyServer {
                 "method": parts.method.as_str(),
                 "originalUrl": parts.uri.to_string(),
                 "targetUrl": target_url.to_string(),
-                "headers": parts.headers.iter()
-                    .map(|(k, v)| format!("{}: {}", k.as_str(), v.to_str().unwrap_or("")))
-                    .collect::<Vec<_>>()
-                    .join(", "),
-                "body": request_body.chars().take(10000).collect::<String>(),
+                "headers": serde_json::json!(parts.headers.iter()
+                    .filter_map(|(k, v)| {
+                        v.to_str().ok().map(|val| (k.as_str(), val))
+                    })
+                    .collect::<std::collections::HashMap<&str, &str>>()),
+                "body": request_body,
                 "userAgent": user_agent,
                 "originator": originator,
                 "contentType": parts.headers.get("content-type")
@@ -745,11 +746,12 @@ impl ProxyServer {
                 "method": parts.method.as_str(),
                 "originalUrl": parts.uri.to_string(),
                 "targetUrl": target_url.to_string(),
-                "headers": parts.headers.iter()
-                    .map(|(k, v)| format!("{}: {}", k.as_str(), v.to_str().unwrap_or("")))
-                    .collect::<Vec<_>>()
-                    .join(", "),
-                "body": request_body.chars().take(10000).collect::<String>(),
+                "headers": serde_json::json!(parts.headers.iter()
+                    .filter_map(|(k, v)| {
+                        v.to_str().ok().map(|val| (k.as_str(), val))
+                    })
+                    .collect::<std::collections::HashMap<&str, &str>>()),
+                "body": request_body,
                 "userAgent": user_agent,
                 "originator": originator,
                 "contentType": parts.headers.get("content-type")


### PR DESCRIPTION
## Description
<!-- A brief summary of the changes in this pull request. -->
This pull request updates how request headers and bodies are logged in both the Node.js and Rust implementations of the proxy server. The changes improve the structure and completeness of logged data by switching header serialization to JSON and removing previous truncation of request bodies.

**Logging improvements:**

* In `node/src/server.js`, the request body is no longer truncated to 10,000 characters before logging; the full body is now logged after redacting sensitive content.
* In `rust/src/server.rs`, request headers are now serialized as a JSON object rather than a comma-separated string, making them easier to parse and use. [[1]](diffhunk://#diff-6655e8a283154516345c82fa6c988f4751a5c180ca4afed6a13a053ad2cf218fL683-R688) [[2]](diffhunk://#diff-6655e8a283154516345c82fa6c988f4751a5c180ca4afed6a13a053ad2cf218fL748-R754)
* In `rust/src/server.rs`, the request body is now logged in full, rather than being truncated to 10,000 characters. [[1]](diffhunk://#diff-6655e8a283154516345c82fa6c988f4751a5c180ca4afed6a13a053ad2cf218fL683-R688) [[2]](diffhunk://#diff-6655e8a283154516345c82fa6c988f4751a5c180ca4afed6a13a053ad2cf218fL748-R754)

## Checklist
- [x] I tested my changes
- [x] I reviewed my own code