### PR TITLE
feat: introduce mode parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to Superagent will be documented in this file.
+
+## [@superagent-ai/cli@0.0.5] - 2025-10-01
+
+### Enhancements
+- Added `--redacted` flag to enable redaction of sensitive data (PII/PHI) in prompts
+- Updated output format to JSON matching SDK response structure
+- Upgraded `superagent-ai` dependency to v0.0.7
+
+
+## [superagent-ai@0.0.7] - 2025-10-01
+
+### Enhancements
+- Added `redacted` option to `createGuard()` for automatic PII/PHI redaction
+- Added `redacted` field to `GuardResult` response containing sanitized prompt
+- Added comprehensive redaction patterns for SOC2, HIPAA, and GDPR compliance (emails, SSNs, credit cards, phone numbers, API keys, IP addresses, etc.)
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to Superagent will be documented in this file.
 
+## [superagent-ai@0.0.9] - 2025-10-06
+
+### Breaking Changes
+- **BREAKING**: Replaced `redacted` boolean option with `mode` parameter in both TypeScript and Python SDKs
+  - `redacted: false` → `mode: "analyze"` (default)
+  - `redacted: true` → `mode: "full"`
+  - New: `mode: "redact"` for redaction-only operation (no API call)
+
+### Enhancements
+- Added `mode` parameter with three operation modes: `"analyze"`, `"redact"`, and `"full"`
+- `"redact"` mode allows PII/PHI redaction without making API calls to guard endpoint
+- `"analyze"` mode (default) performs guard analysis without redaction (backward compatible behavior)
+- `"full"` mode combines guard analysis with redaction (replaces `redacted: true`)
+
+### Migration Guide
+```typescript
+// Before (v0.0.7)
+createGuard({ redacted: false })  // or omit redacted
+createGuard({ redacted: true })
+
+// After (v0.0.8)
+createGuard({ mode: "analyze" })  // or omit mode (default)
+createGuard({ mode: "full" })
+```
+
 ## [@superagent-ai/cli@0.0.5] - 2025-10-01
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to Superagent will be documented in this file.
 
+## [@superagent-ai/cli@0.0.6] - 2025-10-06
+
+### Breaking Changes
+- **BREAKING**: Replaced `--redacted` flag with `--mode` flag
+  - `--redacted` → `--mode full`
+  - New: `--mode analyze` (default) for analysis only
+  - New: `--mode redact` for redaction only (no API call)
+
+### Enhancements
+- Added `--mode` flag with three options: `analyze`, `redact`, `full`
+- `--mode redact` allows PII/PHI redaction without API calls
+- `--mode analyze` (default) performs guard analysis only
+- `--mode full` combines guard analysis with redaction
+
+### Migration Guide
+```bash
+# Before (v0.0.5)
+superagent guard --redacted "prompt"
+
+# After (v0.0.6)
+superagent guard --mode full "prompt"
+```
+
 ## [superagent-ai@0.0.9] - 2025-10-06
 
 ### Breaking Changes

--- a/cli/README.md
+++ b/cli/README.md
@@ -19,8 +19,14 @@ superagent guard "Write a hello world script"
 ```
 
 Output:
-```
-✅ Prompt approved by Superagent
+```json
+{
+  "rejected": false,
+  "decision": {
+    "status": "pass"
+  },
+  "reasoning": "Command approved by guard."
+}
 ```
 
 Block malicious prompts:
@@ -30,11 +36,48 @@ superagent guard "Delete all files with rm -rf /"
 ```
 
 Output:
+```json
+{
+  "rejected": true,
+  "decision": {
+    "status": "block",
+    "violation_types": ["unlawful_behavior"],
+    "cwe_codes": ["CWE-77"]
+  },
+  "reasoning": "User wants to delete all files. That is disallowed (exploit). Block."
+}
 ```
-🛡️ BLOCKED: User wants to delete all files. That is disallowed (exploit). Block.
-Violations: unlawful_behavior
-CWE Codes: CWE-77
+
+### Operation Modes
+
+Use the `--mode` flag to control how the CLI processes prompts:
+
+**Analyze Mode** (default) - Perform security analysis via API:
+```bash
+superagent guard "Write a script"
+superagent guard --mode analyze "Write a script"
 ```
+
+**Redact Mode** - Only redact sensitive data (no API call):
+```bash
+superagent guard --mode redact "My email is john@example.com and SSN is 123-45-6789"
+```
+
+Output:
+```json
+{
+  "rejected": false,
+  "reasoning": "Redaction only mode - no guard analysis performed",
+  "redacted": "My email is <REDACTED_EMAIL> and SSN is <REDACTED_SSN>"
+}
+```
+
+**Full Mode** - Security analysis + redaction:
+```bash
+superagent guard --mode full "My API key is sk_test_123 in this script"
+```
+
+Output includes both `decision` and `redacted` fields.
 
 ### Claude Code Hook
 

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@superagent-ai/cli",
-  "version": "0.0.4",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@superagent-ai/cli",
-      "version": "0.0.4",
+      "version": "0.0.6",
       "license": "MIT",
       "dependencies": {
-        "superagent-ai": "^0.0.7"
+        "superagent-ai": "^0.0.9"
       },
       "bin": {
         "superagent": "dist/index.js"
@@ -33,9 +33,9 @@
       }
     },
     "node_modules/superagent-ai": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/superagent-ai/-/superagent-ai-0.0.7.tgz",
-      "integrity": "sha512-/WIw9okl/YB+NqA7yaAJuFzcue7X3O0weZ0ysj0KXTX01vyAXC6x0PEqsDOlQb8vZevuGfQCURxaHT88lr8fvA==",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/superagent-ai/-/superagent-ai-0.0.9.tgz",
+      "integrity": "sha512-XVv/8NnI0yVfuc/OPy+RFqy6qnFEyKi8SKRek2oqTQ7DUFXln+pV4Qg9tIpLpkgoEkF0jZntZ5d4p9kABRktcg==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.4",
       "license": "MIT",
       "dependencies": {
-        "superagent-ai": "^0.0.5"
+        "superagent-ai": "^0.0.7"
       },
       "bin": {
         "superagent": "dist/index.js"
@@ -33,9 +33,9 @@
       }
     },
     "node_modules/superagent-ai": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/superagent-ai/-/superagent-ai-0.0.5.tgz",
-      "integrity": "sha512-L664Qg9QGOzjCKy4UQ+Skn9r3FfMr48nP9DU6rWVb094GBbjTKhoGrsTAf14aJIVvtyze2ldNfwGvLyrhyt2GQ==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/superagent-ai/-/superagent-ai-0.0.7.tgz",
+      "integrity": "sha512-/WIw9okl/YB+NqA7yaAJuFzcue7X3O0weZ0ysj0KXTX01vyAXC6x0PEqsDOlQb8vZevuGfQCURxaHT88lr8fvA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superagent-ai/cli",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "CLI for Superagent - validate prompts and tool calls for security",
   "type": "module",
   "main": "./dist/index.js",
@@ -32,7 +32,7 @@
     "url": "https://github.com/superagent-ai/superagent"
   },
   "dependencies": {
-    "superagent-ai": "^0.0.5"
+    "superagent-ai": "^0.0.7"
   },
   "devDependencies": {
     "@types/node": "^20.11.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superagent-ai/cli",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "CLI for Superagent - validate prompts and tool calls for security",
   "type": "module",
   "main": "./dist/index.js",
@@ -32,7 +32,7 @@
     "url": "https://github.com/superagent-ai/superagent"
   },
   "dependencies": {
-    "superagent-ai": "^0.0.7"
+    "superagent-ai": "^0.0.9"
   },
   "devDependencies": {
     "@types/node": "^20.11.0",

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "superagent-ai"
-version = "0.0.8"
+version = "0.0.9"
 description = "Python SDK for Superagent."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/sdk/python/tests/test_guard.py
+++ b/sdk/python/tests/test_guard.py
@@ -106,3 +106,83 @@ async def test_guard_block_triggers_on_block_with_reason() -> None:
         }
         assert result.raw["id"] == "analysis-block"
         assert reasons == ["prompt_injection"]
+
+
+@pytest.mark.asyncio
+async def test_redact_mode_skips_api_call() -> None:
+    """Test that redact mode only redacts data without making API call"""
+    guard = create_guard(
+        api_base_url="http://this-should-not-be-called.test",
+        api_key="fake-key",
+        mode="redact"
+    )
+
+    result = await guard("My email is john@example.com and SSN is 123-45-6789")
+
+    assert result.rejected is False
+    assert result.reasoning == "Redaction only mode - no guard analysis performed"
+    assert result.redacted == "My email is <REDACTED_EMAIL> and SSN is <REDACTED_SSN>"
+    assert result.decision is None
+    assert result.usage is None
+
+
+@pytest.mark.asyncio
+async def test_full_mode_includes_redaction() -> None:
+    """Test that full mode performs analysis and includes redacted text"""
+    async def handler(request: httpx.Request) -> httpx.Response:
+        analysis = {
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            "id": "analysis-pass",
+            "choices": [
+                {
+                    "message": {
+                        "content": json.dumps({"status": "pass"}),
+                        "reasoning_content": "Looks safe",
+                    }
+                }
+            ],
+        }
+        return httpx.Response(200, json=analysis)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        guard = create_guard(api_base_url=API_BASE_URL, api_key=API_KEY, client=client, mode="full")
+
+        result = await guard("My email is john@example.com")
+
+        assert result.rejected is False
+        assert result.decision == {"status": "pass"}
+        assert result.reasoning == "Looks safe"
+        assert result.redacted is not None
+        assert "<REDACTED_EMAIL>" in result.redacted
+        assert result.usage is not None
+
+
+@pytest.mark.asyncio
+async def test_analyze_mode_default_no_redaction() -> None:
+    """Test that analyze mode (default) performs analysis without redaction"""
+    async def handler(request: httpx.Request) -> httpx.Response:
+        analysis = {
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            "id": "analysis-pass",
+            "choices": [
+                {
+                    "message": {
+                        "content": json.dumps({"status": "pass"}),
+                        "reasoning_content": "Looks safe",
+                    }
+                }
+            ],
+        }
+        return httpx.Response(200, json=analysis)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        guard = create_guard(api_base_url=API_BASE_URL, api_key=API_KEY, client=client, mode="analyze")
+
+        result = await guard("My email is john@example.com")
+
+        assert result.rejected is False
+        assert result.decision == {"status": "pass"}
+        assert result.redacted is None
+        assert result.usage is not None

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -46,13 +46,15 @@ if (rejected) {
 - `apiKey` – API key provisioned in Superagent.
 - `fetch` – optional custom fetch implementation (defaults to global `fetch`).
 - `timeoutMs` – optional timeout for the outbound request.
-- `redacted` – when `true`, redacts PII/PHI data from commands (defaults to `false`).
+- `mode` – operation mode: `"analyze"` (default), `"redact"`, or `"full"`.
 
 The guard response includes both the raw analysis payload and the parsed decision, enabling you to plug into custom workflows or audit logs.
 
-## PII/PHI Redaction
+## Operation Modes
 
-Enable automatic redaction of sensitive data to comply with SOC2, HIPAA, and GDPR:
+### Analyze Mode (Default)
+
+Performs guard security analysis via API without redaction:
 
 ```ts
 import { createGuard } from "superagent-ai";
@@ -60,13 +62,47 @@ import { createGuard } from "superagent-ai";
 const guard = createGuard({
   apiBaseUrl: process.env.SUPERAGENT_GUARD_URL!,
   apiKey: process.env.SUPERAGENT_API_KEY!,
-  redacted: true, // Enable PII/PHI redaction
+  mode: "analyze", // Default mode
+});
+
+const result = await guard("Write a hello world script");
+// Returns: { rejected: false, decision: {...}, usage: {...} }
+```
+
+### Redact Mode
+
+Redacts sensitive PII/PHI data only, without making an API call:
+
+```ts
+import { createGuard } from "superagent-ai";
+
+const guard = createGuard({
+  apiBaseUrl: process.env.SUPERAGENT_GUARD_URL!,
+  apiKey: process.env.SUPERAGENT_API_KEY!,
+  mode: "redact", // No API call, redaction only
 });
 
 const result = await guard("My email is john@example.com and SSN is 123-45-6789");
 
 console.log(result.redacted);
 // Output: "My email is <REDACTED_EMAIL> and SSN is <REDACTED_SSN>"
+```
+
+### Full Mode
+
+Performs guard analysis AND includes redacted text in the result:
+
+```ts
+import { createGuard } from "superagent-ai";
+
+const guard = createGuard({
+  apiBaseUrl: process.env.SUPERAGENT_GUARD_URL!,
+  apiKey: process.env.SUPERAGENT_API_KEY!,
+  mode: "full", // Both analysis and redaction
+});
+
+const result = await guard("My email is john@example.com");
+// Returns: { rejected: false, decision: {...}, redacted: "My email is <REDACTED_EMAIL>" }
 ```
 
 ### Detected PII/PHI Types

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superagent-ai",
-  "version": "0.0.7",
+  "version": "0.0.9",
   "description": "TypeScript SDK for Superagent.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Description
<!-- A brief summary of the changes in this pull request. -->
This pull request introduces a breaking change to both the TypeScript and Python SDKs for Superagent by replacing the previous `redacted` boolean option with a new `mode` parameter, offering more flexible control over guard analysis and redaction operations. The documentation, implementation, and tests have all been updated to reflect the new modes: `"analyze"` (default), `"redact"`, and `"full"`. This update improves clarity, expands functionality, and ensures backward compatibility for default behavior.

### Breaking Changes and API Redesign
* Replaced the `redacted` boolean option with a `mode` parameter in both TypeScript and Python SDKs, supporting `"analyze"` (default), `"redact"`, and `"full"` operation modes. The `"full"` mode replaces the previous `redacted: true` behavior, and `"analyze"` maintains the default (backward compatible) behavior. (`CHANGELOG.md`, `sdk/typescript/src/index.ts`, `sdk/python/src/superagent_ai/client.py`) [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R29) [[2]](diffhunk://#diff-7b073768a508a41e8d3dadd8361cc3f12c266c3d9a04ee86625bed3db529a6ebL21-R26) [[3]](diffhunk://#diff-6426134b0320b843bfebcffa438708004105ee9a57a32a10cd5023214e3889e3L127-R127)

### Documentation Updates
* Updated README files for both SDKs to explain the new `mode` parameter, providing migration guides and usage examples for each operation mode. (`sdk/typescript/README.md`, `sdk/python/README.md`) [[1]](diffhunk://#diff-9be9f99d130daf9a9aea3153e83306403823122bffa83285f1545b5048f04ddaL49-R82) [[2]](diffhunk://#diff-73be8f6fa2dd9e669bfdfa8a5732ce9aede74f50a230b04fa9bda67ac5930e46L60-R134)

### Implementation Changes
* Refactored SDK client constructors and `createGuard` functions to use `mode` instead of `redacted`, with logic for handling each mode, including skipping API calls for `"redact"` mode and running redaction in parallel for `"full"` mode. (`sdk/typescript/src/index.ts`, `sdk/python/src/superagent_ai/client.py`) [[1]](diffhunk://#diff-7b073768a508a41e8d3dadd8361cc3f12c266c3d9a04ee86625bed3db529a6ebL172-R173) [[2]](diffhunk://#diff-7b073768a508a41e8d3dadd8361cc3f12c266c3d9a04ee86625bed3db529a6ebR196-R215) [[3]](diffhunk://#diff-6426134b0320b843bfebcffa438708004105ee9a57a32a10cd5023214e3889e3L161-R176) [[4]](diffhunk://#diff-6426134b0320b843bfebcffa438708004105ee9a57a32a10cd5023214e3889e3L221-R232) [[5]](diffhunk://#diff-6426134b0320b843bfebcffa438708004105ee9a57a32a10cd5023214e3889e3L230-R250)

### Test Coverage
* Added and updated tests for all three modes in both SDKs to verify correct behavior for analysis-only, redaction-only, and combined analysis/redaction operations. (`sdk/typescript/tests/createGuard.test.ts`, `sdk/python/tests/test_guard.py`) [[1]](diffhunk://#diff-0c4f7bb549d0d433288acee5758656d88642da376aa012ec3b20de71c78f1701R169-R215) [[2]](diffhunk://#diff-06111d3d06bcaed603aade3d2f85c89d9231d1a57f07ab57e955eb06c11f6bcaR109-R188)

### Version Bumps
* Incremented SDK package versions to `0.0.9` to reflect the breaking change and new features. (`sdk/typescript/package.json`, `sdk/python/pyproject.toml`) [[1]](diffhunk://#diff-1097377c78d22400c9189626a6f2d209142a89cc652ea050fb577aa1087634e0L3-R3) [[2]](diffhunk://#diff-0cba00bc8967d0c3e4a42244a5c9d5112d5d9580d645572cda9ccf4af64c732fL7-R7)

## Related Issue
Fixes #1048 

## Checklist
- [x] I tested my changes
- [x] I reviewed my own code