### PR TITLE
docs(examples): secure agent memory with Hindsight

### DIFF
--- a/docs/content/docs/sdk/examples/secure-agent-memory.mdx
+++ b/docs/content/docs/sdk/examples/secure-agent-memory.mdx
@@ -1,0 +1,79 @@
+---
+title: Secure your agent's memory
+description: Guard against prompt injection and redact PII before content enters your agent's long-term memory using Superagent
+---
+
+When agents store conversations and documents in long-term memory, that memory becomes an attack surface: a poisoned document can plant a prompt-injection payload that fires on a later recall, and raw PII can be persisted indefinitely. Run Superagent **Guard** and **Redact** on content before it is stored, and guard queries before they hit the memory store.
+
+This example uses [Hindsight](https://github.com/vectorize-io/hindsight), an open-source long-term memory engine, via the [`hindsight-superagent`](https://pypi.org/project/hindsight-superagent/) package — a thin `SafeHindsight` wrapper that applies Superagent safety checks around each memory operation.
+
+## Prerequisites
+
+- Python 3.10 or higher
+- A Superagent API key ([sign up here](https://superagent.sh))
+- A running Hindsight instance ([quickstart](https://github.com/vectorize-io/hindsight#quick-start)) or a free [Hindsight Cloud](https://hindsight.vectorize.io) account
+
+## Install dependencies
+
+```bash title="Terminal"
+pip install hindsight-superagent
+```
+
+Set your environment variables:
+
+```bash title=".env"
+SUPERAGENT_API_KEY=your-key
+```
+
+## Guard and redact on write, guard on read
+
+`SafeHindsight` wraps the Hindsight client. On `retain`, content is guarded for injection and then redacted of PII before storage. On `recall`/`reflect`, the query is guarded before it reaches the memory store.
+
+```python title="secure_memory.py"
+import asyncio
+from hindsight_superagent import SafeHindsight
+
+safe = SafeHindsight(
+    bank_id="user-123",
+    hindsight_api_url="http://localhost:8888",  # or omit for Hindsight Cloud
+    guard_model="openai/gpt-4.1-nano",
+    redact_model="openai/gpt-4.1-nano",
+)
+
+async def main():
+    # Content is guarded (injection blocked) and PII is redacted before storage
+    await safe.retain("John's email is john@acme.com and he prefers dark mode")
+
+    # The query is guarded before recall runs
+    results = await safe.recall("What are the user's preferences?")
+    for r in results.results:
+        print(r.text)
+
+    await safe.aclose()
+
+asyncio.run(main())
+```
+
+The stored memory keeps the useful fact ("prefers dark mode") while the PII ("john@acme.com") is stripped by Redact, and any retain or query carrying an injection payload is blocked by Guard before it can reach the memory store.
+
+## How it works
+
+```text
+Content → Guard (block injection) → Redact (strip PII) → store in memory
+Query   → Guard (block injection) → recall / reflect
+```
+
+Guard and Redact run per item, so bulk ingestion is protected too. If Guard blocks any item in a batch, the whole batch is aborted before anything is written:
+
+```python
+await safe.retain_batch([
+    {"content": "John's email is john@acme.com"},
+    {"content": "Phone: 555-1234", "context": "contacts"},
+])
+```
+
+## Resources
+
+- [hindsight-superagent on PyPI](https://pypi.org/project/hindsight-superagent/)
+- [Integration source](https://github.com/vectorize-io/hindsight/tree/main/hindsight-integrations/superagent)
+- [Superagent Python SDK](/docs/sdk/sdk/python)


### PR DESCRIPTION
Adds an example showing how to use Superagent **Guard** + **Redact** to protect an agent's long-term memory — blocking prompt-injection payloads and stripping PII before content is stored, and guarding queries before recall.

It uses [Hindsight](https://github.com/vectorize-io/hindsight) (open-source memory engine) via the [`hindsight-superagent`](https://pypi.org/project/hindsight-superagent/) `SafeHindsight` wrapper, which applies Superagent safety checks around each memory operation. Directly analogous to the existing `secure-rag-pipeline` example, for the memory write/read path.

- New page: `docs/content/docs/sdk/examples/secure-agent-memory.mdx`

Python example (uses your Python SDK under the hood). Happy to adjust framing or move it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition with no runtime, auth, or application code changes.
> 
> **Overview**
> Adds a new SDK docs example page **`secure-agent-memory.mdx`** that walks through protecting long-term agent memory with Superagent **Guard** and **Redact** via Hindsight’s **`SafeHindsight`** wrapper (`hindsight-superagent`).
> 
> The page covers prerequisites, install/env setup, a full **`retain` / `recall`** Python sample (guard + redact on write, guard on read), a short flow diagram, **`retain_batch`** behavior (whole batch aborted if Guard blocks any item), and links to PyPI, integration source, and the Python SDK.
> 
> **Note:** The diff only adds the MDX file; it does not update `docs/content/docs/sdk/meta.json`, so the page may not appear in the examples nav until that is added separately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13037a68dbb6f45d7ac056fe91aaba9f3f81d8bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->