### PR TITLE
fix(sdk/python): MIME type helpers must compare case-insensitively

### DIFF
--- a/sdk/python/src/safety_agent/utils/input_processor.py
+++ b/sdk/python/src/safety_agent/utils/input_processor.py
@@ -122,11 +122,13 @@ def _validate_url(url: str) -> None:
 
 def _is_image_mime_type(mime_type: str) -> bool:
     """Check if MIME type is an image."""
+    mime_type = mime_type.lower()
     return any(mime_type.startswith(t) for t in IMAGE_MIME_TYPES)
 
 
 def _is_text_mime_type(mime_type: str) -> bool:
     """Check if MIME type is text-based."""
+    mime_type = mime_type.lower()
     return (
         any(mime_type.startswith(t) for t in TEXT_MIME_TYPES)
         or mime_type.startswith("text/")
@@ -135,6 +137,7 @@ def _is_text_mime_type(mime_type: str) -> bool:
 
 def _is_pdf_mime_type(mime_type: str) -> bool:
     """Check if MIME type is PDF."""
+    mime_type = mime_type.lower()
     return any(mime_type.startswith(t) for t in PDF_MIME_TYPES)
 
 

--- a/sdk/python/tests/test_input_processor.py
+++ b/sdk/python/tests/test_input_processor.py
@@ -72,6 +72,18 @@ class TestMimeTypeHelpers:
     def test_non_pdf(self):
         assert _is_pdf_mime_type("text/plain") is False
 
+    # Media types are case-insensitive per RFC 7231 3.1.1.1, and real servers
+    # send non-lowercase Content-Type headers - the mime helpers must not
+    # depend on the caller having already normalized the case.
+    def test_pdf_mime_type_uppercase(self):
+        assert _is_pdf_mime_type("APPLICATION/PDF") is True
+
+    def test_image_mime_type_uppercase(self):
+        assert _is_image_mime_type("IMAGE/PNG") is True
+
+    def test_text_mime_type_mixed_case(self):
+        assert _is_text_mime_type("Text/Html") is True
+
 
 class TestGetMimeTypeFromUrl:
     @pytest.mark.parametrize("url,expected", [


### PR DESCRIPTION
## Description

`_is_image_mime_type`, `_is_text_mime_type` and `_is_pdf_mime_type` in `sdk/python/src/safety_agent/utils/input_processor.py` matched against lowercase-only prefix lists without lowercasing the input first. Media types are case-insensitive per [RFC 7231 §3.1.1.1](https://www.rfc-editor.org/rfc/rfc7231#section-3.1.1.1), and real servers do send non-lowercase `Content-Type` headers. Neither caller (`_fetch_url`, `_process_bytes`) lowercases `content_type`/`detected_mime` before calling these helpers, so e.g. a server responding with `Content-Type: APPLICATION/PDF` caused `_fetch_url` to raise `RuntimeError: Unsupported content type: APPLICATION/PDF` instead of processing the PDF — rejecting a fully valid response.

```python
>>> _is_pdf_mime_type("APPLICATION/PDF")
False   # before this fix - wrong
```

Fixed by lowercasing the input at the top of each helper.

## Type of Change
- [x] Bug fix

## Testing

Added `test_pdf_mime_type_uppercase`, `test_image_mime_type_uppercase`, and `test_text_mime_type_mixed_case` to `tests/test_input_processor.py`. Confirmed via `git stash` that they fail against the pre-fix code and pass after.

- `uv run pytest` (from `sdk/python/`) — 78 passed, no regressions.

## Checklist
- [x] Code follows project style guidelines
- [x] Tests pass locally
- [x] Documentation updated (if needed) — n/a, internal helper functions

## AI disclosure

Developed with AI assistance (Claude Code), which located the bug while investigating `input_processor.py` for defects. I reviewed the diff, independently reproduced the case-sensitivity bug and the fix by executing both against the actual functions, and ran the tests myself before opening this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized bug fix in input classification with new unit tests and no security or API contract changes.
> 
> **Overview**
> **`_is_image_mime_type`**, **`_is_text_mime_type`**, and **`_is_pdf_mime_type`** now lowercase the input before matching prefix lists, so non-lowercase `Content-Type` values (e.g. `APPLICATION/PDF`) are recognized per RFC 7231.
> 
> That fixes URL fetch and byte processing paths that previously treated valid responses as unsupported and raised `RuntimeError: Unsupported content type: …`.
> 
> Tests add uppercase and mixed-case coverage for the three helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c31887d490b839aad2b41313bbdffa05bdf2c2f3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->