### PR TITLE
docs: add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,34 @@
+# Security Policy
+
+## Supported Versions
+
+Security updates are provided for the latest released version of each
+Superagent package. Please upgrade to the latest version before reporting an
+issue that may already have been fixed.
+
+## Reporting a Vulnerability
+
+Please do not report security vulnerabilities through public GitHub issues,
+discussions, or Discord.
+
+Report vulnerabilities privately through
+[GitHub Security Advisories](https://github.com/superagent-ai/superagent/security/advisories/new).
+Include, when possible:
+
+- The affected package, version, and configuration
+- A description of the vulnerability and its potential impact
+- Reproduction steps or a minimal proof of concept
+- Any known mitigations or suggested fixes
+
+We will acknowledge the report as soon as possible, keep you informed while it
+is investigated, and coordinate disclosure after a fix is available. Please
+allow a reasonable amount of time for us to investigate and address the issue
+before publishing details.
+
+## Scope
+
+This policy covers the code and packages maintained in this repository. For
+vulnerabilities in third-party dependencies, report the issue to the relevant
+maintainer as well as to us when it directly affects Superagent users.
+
+Thank you for helping keep Superagent and its users safe.


### PR DESCRIPTION
## Description
Add a security policy that documents supported versions, private vulnerability reporting through GitHub Security Advisories, disclosure expectations, and project scope.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing
Not run (documentation-only change).

## Checklist
- [x] Code follows project style guidelines
- [x] Tests pass locally
- [x] Documentation updated (if needed)