### PR TITLE
fix: prevent URL input SSRF

### DIFF
--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -71,6 +71,10 @@ Guard supports multiple input types:
 - **Bytes/Files**: Analyzed based on content type
 - **PDFs**: Text extracted and analyzed per page
 
+Remote URLs must resolve exclusively to public IP addresses. Redirect targets
+are revalidated, and downloads are limited to 5 redirects, 30 seconds, and
+25 MiB.
+
 ```python
 # URL input
 result = await client.guard(input="https://example.com/document.pdf")

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "httpx>=0.27.0",
     "pypdf>=5.0.0",
     "daytona-sdk>=0.129.0",
+    "aiohttp>=3.14.3",
 ]
 
 [project.urls]

--- a/sdk/python/src/safety_agent/utils/input_processor.py
+++ b/sdk/python/src/safety_agent/utils/input_processor.py
@@ -3,13 +3,10 @@ Input processor for handling various input types (text, URLs, images, PDFs)
 """
 
 import base64
-import ipaddress
-import socket
 from urllib.parse import urlparse
 
-import httpx
-
 from ..types import GuardInput, ProcessedInput
+from .safe_url_fetcher import fetch_public_url
 
 # Image MIME types supported by vision models
 IMAGE_MIME_TYPES = [
@@ -39,85 +36,6 @@ TEXT_MIME_TYPES = [
 def _is_url_string(input_str: str) -> bool:
     """Check if a string looks like a URL."""
     return input_str.startswith("http://") or input_str.startswith("https://")
-
-
-def _is_private_ip(hostname: str) -> bool:
-    """
-    Check if a hostname resolves to a private/internal IP address.
-    
-    Blocks:
-    - localhost and 127.0.0.0/8 (loopback)
-    - 10.0.0.0/8 (private)
-    - 172.16.0.0/12 (private)
-    - 192.168.0.0/16 (private)
-    - localhost hostname
-    """
-    # Check for localhost hostname
-    if hostname.lower() in ("localhost", "localhost.localdomain", "local"):
-        return True
-    
-    # Try to resolve hostname to IP address
-    try:
-        # Get the first IP address from hostname
-        ip_str = socket.gethostbyname(hostname)
-        ip = ipaddress.ip_address(ip_str)
-        
-        # Check if it's a private IP
-        return ip.is_loopback or ip.is_private or ip.is_link_local or ip.is_multicast
-    except (socket.gaierror, socket.herror, ValueError):
-        # If hostname can't be resolved or is not a valid IP, check if it's a direct IP
-        try:
-            ip = ipaddress.ip_address(hostname)
-            return ip.is_loopback or ip.is_private or ip.is_link_local or ip.is_multicast
-        except ValueError:
-            # Not a valid IP address, but we'll allow it (could be a domain)
-            # The actual connection will fail if it's invalid
-            return False
-
-
-def _validate_url(url: str) -> None:
-    """
-    Validate URL for security concerns.
-    
-    Raises ValueError with descriptive message if URL is invalid or unsafe.
-    
-    Checks:
-    - URL format is valid
-    - Protocol is http or https only
-    - Hostname is not empty
-    - No private/internal IP addresses
-    - No localhost access
-    - No file:// protocol
-    - URL length is reasonable (max 2048 characters)
-    """
-    # Check URL length
-    MAX_URL_LENGTH = 2048
-    if len(url) > MAX_URL_LENGTH:
-        raise ValueError(f"Invalid URL: URL exceeds maximum length of {MAX_URL_LENGTH} characters")
-    
-    # Parse URL
-    try:
-        parsed = urlparse(url)
-    except Exception as e:
-        raise ValueError(f"Invalid URL: malformed URL format - {str(e)}")
-    
-    # Check protocol
-    protocol = parsed.scheme.lower()
-    if protocol not in ("http", "https"):
-        if protocol == "file":
-            raise ValueError("Invalid URL: file:// protocol is not allowed")
-        raise ValueError(f"Invalid URL: protocol must be http or https, got {protocol}")
-    
-    # Check hostname
-    hostname = parsed.hostname
-    if not hostname:
-        raise ValueError("Invalid URL: hostname is required")
-    
-    # Check for private/internal IP addresses
-    if _is_private_ip(hostname):
-        if hostname.lower() in ("localhost", "127.0.0.1", "::1") or hostname.startswith("127."):
-            raise ValueError("Invalid URL: localhost access is not allowed")
-        raise ValueError("Invalid URL: private/internal IP addresses are not allowed")
 
 
 def _is_image_mime_type(mime_type: str) -> bool:
@@ -189,56 +107,36 @@ async def _extract_pdf_pages(data: bytes) -> list[str]:
 
 async def _fetch_url(url: str) -> ProcessedInput:
     """Fetch content from a URL and return as ProcessedInput."""
-    # Validate URL for security before making any network requests
-    _validate_url(url)
-    
-    async with httpx.AsyncClient() as client:
-        response = await client.get(url, follow_redirects=True, timeout=30.0)
+    response = await fetch_public_url(url)
+    content_type = (
+        response.content_type
+        or _get_mime_type_from_url(response.final_url)
+        or "text/plain"
+    )
 
-        if response.status_code != 200:
-            raise RuntimeError(
-                f"Failed to fetch URL: {response.status_code} {response.reason_phrase}"
-            )
+    if _is_pdf_mime_type(content_type):
+        pages = await _extract_pdf_pages(response.data)
+        return ProcessedInput(
+            type="pdf",
+            pages=pages,
+            mime_type=content_type,
+        )
 
-        # Get content type from response or infer from URL
-        content_type = response.headers.get("content-type", "").split(";")[0].strip()
+    if _is_image_mime_type(content_type):
+        return ProcessedInput(
+            type="image",
+            image_base64=_bytes_to_base64(response.data),
+            mime_type=content_type,
+        )
 
-        if not content_type:
-            content_type = _get_mime_type_from_url(url) or "text/plain"
-
-        data = response.content
-
-        if _is_pdf_mime_type(content_type):
-            pages = await _extract_pdf_pages(data)
-            return ProcessedInput(
-                type="pdf",
-                pages=pages,
-                mime_type=content_type,
-            )
-
-        if _is_image_mime_type(content_type):
-            return ProcessedInput(
-                type="image",
-                image_base64=_bytes_to_base64(data),
-                mime_type=content_type,
-            )
-
-        if _is_text_mime_type(content_type):
-            return ProcessedInput(
-                type="text",
-                text=data.decode("utf-8"),
-                mime_type=content_type,
-            )
-
-        # For other content types, try to read as text
-        try:
-            return ProcessedInput(
-                type="text",
-                text=data.decode("utf-8"),
-                mime_type=content_type,
-            )
-        except UnicodeDecodeError:
-            raise RuntimeError(f"Unsupported content type: {content_type}")
+    try:
+        return ProcessedInput(
+            type="text",
+            text=response.data.decode("utf-8"),
+            mime_type=content_type,
+        )
+    except UnicodeDecodeError:
+        raise RuntimeError(f"Unsupported content type: {content_type}")
 
 
 async def _process_bytes(data: bytes, mime_type: str | None = None) -> ProcessedInput:

--- a/sdk/python/src/safety_agent/utils/safe_url_fetcher.py
+++ b/sdk/python/src/safety_agent/utils/safe_url_fetcher.py
@@ -1,0 +1,189 @@
+"""SSRF-safe remote URL fetching."""
+
+import asyncio
+from dataclasses import dataclass
+import ipaddress
+import socket
+from urllib.parse import urljoin, urlparse
+
+import aiohttp
+from aiohttp.abc import AbstractResolver, ResolveResult
+
+MAX_URL_LENGTH = 2048
+MAX_REDIRECTS = 5
+MAX_RESPONSE_BYTES = 25 * 1024 * 1024
+REQUEST_TIMEOUT_SECONDS = 30.0
+
+
+@dataclass
+class PublicUrlResponse:
+    final_url: str
+    content_type: str
+    data: bytes
+
+
+def _validate_url_syntax(url: str) -> tuple[str, int]:
+    if len(url) > MAX_URL_LENGTH:
+        raise ValueError(
+            f"Invalid URL: URL exceeds maximum length of {MAX_URL_LENGTH} characters"
+        )
+
+    try:
+        parsed = urlparse(url)
+        port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    except ValueError as error:
+        raise ValueError(f"Invalid URL: malformed URL format - {error}") from error
+
+    if parsed.scheme not in ("http", "https"):
+        if parsed.scheme == "file":
+            raise ValueError("Invalid URL: file:// protocol is not allowed")
+        raise ValueError(
+            f"Invalid URL: protocol must be http or https, got {parsed.scheme}"
+        )
+    if not parsed.hostname:
+        raise ValueError("Invalid URL: hostname is required")
+    if parsed.username or parsed.password:
+        raise ValueError("Invalid URL: embedded credentials are not allowed")
+
+    hostname = parsed.hostname.lower()
+    if hostname in ("localhost", "localhost.localdomain", "local"):
+        raise ValueError("Invalid URL: localhost access is not allowed")
+
+    return parsed.hostname, port
+
+
+async def _resolve_public_addresses(
+    hostname: str, port: int
+) -> list[tuple[str, int]]:
+    try:
+        direct_ip = ipaddress.ip_address(hostname)
+        addresses = [
+            (
+                str(direct_ip),
+                socket.AF_INET6 if direct_ip.version == 6 else socket.AF_INET,
+            )
+        ]
+    except ValueError:
+        try:
+            results = await asyncio.get_running_loop().getaddrinfo(
+                hostname,
+                port,
+                family=socket.AF_UNSPEC,
+                type=socket.SOCK_STREAM,
+            )
+        except (socket.gaierror, socket.herror) as error:
+            raise ValueError(
+                "Invalid URL: hostname could not be resolved safely"
+            ) from error
+
+        addresses = []
+        seen: set[tuple[str, int]] = set()
+        for family, _type, _proto, _canonname, sockaddr in results:
+            entry = (sockaddr[0], family)
+            if entry not in seen:
+                seen.add(entry)
+                addresses.append(entry)
+
+    if not addresses or any(
+        not ipaddress.ip_address(address).is_global
+        for address, _family in addresses
+    ):
+        raise ValueError("Invalid URL: private/internal IP addresses are not allowed")
+
+    return addresses
+
+
+class _PinnedResolver(AbstractResolver):
+    def __init__(self, hostname: str, addresses: list[tuple[str, int]]) -> None:
+        self._hostname = hostname.lower()
+        self._addresses = addresses
+
+    async def resolve(
+        self,
+        host: str,
+        port: int = 0,
+        family: socket.AddressFamily = socket.AF_INET,
+    ) -> list[ResolveResult]:
+        if host.lower() != self._hostname:
+            raise OSError("Attempted to resolve an unvalidated hostname")
+
+        return [
+            ResolveResult(
+                hostname=host,
+                host=address,
+                port=port,
+                family=address_family,
+                proto=socket.IPPROTO_TCP,
+                flags=socket.AI_NUMERICHOST,
+            )
+            for address, address_family in self._addresses
+            if family in (socket.AF_UNSPEC, address_family)
+        ]
+
+    async def close(self) -> None:
+        return None
+
+
+async def fetch_public_url(url: str) -> PublicUrlResponse:
+    current_url = url
+    timeout = aiohttp.ClientTimeout(total=REQUEST_TIMEOUT_SECONDS)
+
+    for redirect_count in range(MAX_REDIRECTS + 1):
+        hostname, port = _validate_url_syntax(current_url)
+        addresses = await _resolve_public_addresses(hostname, port)
+        connector = aiohttp.TCPConnector(
+            resolver=_PinnedResolver(hostname, addresses),
+            use_dns_cache=False,
+            family=socket.AF_UNSPEC,
+        )
+
+        async with aiohttp.ClientSession(
+            connector=connector,
+            timeout=timeout,
+            trust_env=False,
+        ) as client:
+            async with client.get(current_url, allow_redirects=False) as response:
+                if 300 <= response.status < 400:
+                    location = response.headers.get("location")
+                    if not location:
+                        raise RuntimeError(
+                            "Failed to fetch URL: redirect is missing Location"
+                        )
+                    if redirect_count == MAX_REDIRECTS:
+                        raise RuntimeError(
+                            f"Failed to fetch URL: exceeded {MAX_REDIRECTS} redirects"
+                        )
+                    current_url = urljoin(current_url, location)
+                    continue
+
+                if response.status != 200:
+                    raise RuntimeError(
+                        f"Failed to fetch URL: {response.status} {response.reason}"
+                    )
+                if (
+                    response.content_length is not None
+                    and response.content_length > MAX_RESPONSE_BYTES
+                ):
+                    raise RuntimeError(
+                        f"Failed to fetch URL: response exceeds {MAX_RESPONSE_BYTES} bytes"
+                    )
+
+                body = bytearray()
+                async for chunk in response.content.iter_chunked(64 * 1024):
+                    body.extend(chunk)
+                    if len(body) > MAX_RESPONSE_BYTES:
+                        raise RuntimeError(
+                            f"Failed to fetch URL: response exceeds {MAX_RESPONSE_BYTES} bytes"
+                        )
+
+                return PublicUrlResponse(
+                    final_url=current_url,
+                    content_type=(
+                        response.headers.get("content-type", "")
+                        .split(";")[0]
+                        .strip()
+                    ),
+                    data=bytes(body),
+                )
+
+    raise RuntimeError(f"Failed to fetch URL: exceeded {MAX_REDIRECTS} redirects")

--- a/sdk/python/tests/test_input_processor.py
+++ b/sdk/python/tests/test_input_processor.py
@@ -4,7 +4,7 @@ Input processor unit tests -- URL validation, SSRF protection, and content type 
 All network calls are mocked so these tests run offline.
 """
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -12,10 +12,8 @@ from safety_agent.utils.input_processor import (
     _get_mime_type_from_url,
     _is_image_mime_type,
     _is_pdf_mime_type,
-    _is_private_ip,
     _is_text_mime_type,
     _is_url_string,
-    _validate_url,
     is_vision_model,
     process_input,
 )
@@ -93,85 +91,6 @@ class TestGetMimeTypeFromUrl:
 
     def test_unknown_extension(self):
         assert _get_mime_type_from_url("https://example.com/file.xyz") is None
-
-
-# ---------------------------------------------------------------------------
-# Private IP / SSRF protection
-# ---------------------------------------------------------------------------
-
-class TestIsPrivateIp:
-    def test_localhost_hostname(self):
-        assert _is_private_ip("localhost") is True
-
-    def test_localhost_ip(self):
-        assert _is_private_ip("127.0.0.1") is True
-
-    def test_loopback_range(self):
-        assert _is_private_ip("127.1.2.3") is True
-
-    @pytest.mark.parametrize("ip", ["10.0.0.1", "10.255.255.255"])
-    def test_10_range(self, ip):
-        assert _is_private_ip(ip) is True
-
-    @pytest.mark.parametrize("ip", ["172.16.0.1", "172.31.255.255"])
-    def test_172_range(self, ip):
-        assert _is_private_ip(ip) is True
-
-    @pytest.mark.parametrize("ip", ["192.168.0.1", "192.168.255.255"])
-    def test_192_range(self, ip):
-        assert _is_private_ip(ip) is True
-
-    def test_link_local(self):
-        assert _is_private_ip("169.254.1.1") is True
-
-    def test_public_ip(self):
-        assert _is_private_ip("8.8.8.8") is False
-
-    @patch("safety_agent.utils.input_processor.socket.gethostbyname", return_value="127.0.0.1")
-    def test_hostname_resolving_to_private(self, _mock):
-        assert _is_private_ip("evil.example.com") is True
-
-    @patch("safety_agent.utils.input_processor.socket.gethostbyname", return_value="93.184.216.34")
-    def test_hostname_resolving_to_public(self, _mock):
-        assert _is_private_ip("example.com") is False
-
-
-# ---------------------------------------------------------------------------
-# URL validation
-# ---------------------------------------------------------------------------
-
-class TestValidateUrl:
-    def test_valid_https(self):
-        # Should not raise
-        _validate_url("https://example.com/page")
-
-    def test_valid_http(self):
-        _validate_url("http://example.com/page")
-
-    def test_file_protocol(self):
-        with pytest.raises(ValueError, match="file:// protocol is not allowed"):
-            _validate_url("file:///etc/passwd")
-
-    def test_ftp_protocol(self):
-        with pytest.raises(ValueError, match="protocol must be http or https"):
-            _validate_url("ftp://example.com/file")
-
-    def test_localhost_blocked(self):
-        with pytest.raises(ValueError, match="localhost access is not allowed"):
-            _validate_url("http://localhost/secret")
-
-    def test_127_blocked(self):
-        with pytest.raises(ValueError, match="localhost access is not allowed"):
-            _validate_url("http://127.0.0.1/secret")
-
-    def test_private_ip_blocked(self):
-        with pytest.raises(ValueError, match="private/internal IP addresses are not allowed"):
-            _validate_url("http://10.0.0.1/internal")
-
-    def test_url_too_long(self):
-        long_url = "https://example.com/" + "a" * 2050
-        with pytest.raises(ValueError, match="URL exceeds maximum length"):
-            _validate_url(long_url)
 
 
 # ---------------------------------------------------------------------------

--- a/sdk/python/tests/test_safe_url_fetcher.py
+++ b/sdk/python/tests/test_safe_url_fetcher.py
@@ -1,0 +1,125 @@
+import socket
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from safety_agent.utils.safe_url_fetcher import (
+    _resolve_public_addresses,
+    fetch_public_url,
+)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://127.0.0.1/admin",
+        "http://10.0.0.1/internal",
+        "http://172.16.0.1/internal",
+        "http://192.168.1.1/internal",
+        "http://169.254.169.254/latest/meta-data/",
+        "http://[::1]/admin",
+        "http://[fc00::1]/internal",
+        "http://[fe80::1]/internal",
+    ],
+)
+async def test_blocks_non_public_destinations(url):
+    with pytest.raises(
+        ValueError,
+        match="private/internal IP addresses are not allowed",
+    ):
+        await fetch_public_url(url)
+
+
+async def test_blocks_hostname_when_any_dns_result_is_non_public():
+    loop = MagicMock()
+    loop.getaddrinfo = AsyncMock(
+        return_value=[
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443)),
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.0.0.1", 443)),
+        ]
+    )
+
+    with patch(
+        "safety_agent.utils.safe_url_fetcher.asyncio.get_running_loop",
+        return_value=loop,
+    ):
+        with pytest.raises(
+            ValueError,
+            match="private/internal IP addresses are not allowed",
+        ):
+            await _resolve_public_addresses("mixed.example", 443)
+
+
+async def test_validates_private_redirect_targets():
+    response = MagicMock()
+    response.status = 302
+    response.headers = {
+        "location": "http://169.254.169.254/latest/meta-data/",
+    }
+    response.__aenter__ = AsyncMock(return_value=response)
+    response.__aexit__ = AsyncMock(return_value=None)
+
+    session = MagicMock()
+    session.get.return_value = response
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch(
+            "safety_agent.utils.safe_url_fetcher.aiohttp.TCPConnector",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "safety_agent.utils.safe_url_fetcher.aiohttp.ClientSession",
+            return_value=session,
+        ),
+    ):
+        with pytest.raises(
+            ValueError,
+            match="private/internal IP addresses are not allowed",
+        ):
+            await fetch_public_url("https://93.184.216.34/redirect")
+
+    session.get.assert_called_once()
+
+
+async def test_downloads_content_from_public_url():
+    class FakeContent:
+        async def iter_chunked(self, _size):
+            yield b"remote document"
+
+    response = MagicMock()
+    response.status = 200
+    response.reason = "OK"
+    response.headers = {"content-type": "text/plain"}
+    response.content_length = len(b"remote document")
+    response.content = FakeContent()
+    response.__aenter__ = AsyncMock(return_value=response)
+    response.__aexit__ = AsyncMock(return_value=None)
+
+    session = MagicMock()
+    session.get.return_value = response
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch(
+            "safety_agent.utils.safe_url_fetcher.aiohttp.TCPConnector",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "safety_agent.utils.safe_url_fetcher.aiohttp.ClientSession",
+            return_value=session,
+        ),
+    ):
+        result = await fetch_public_url("https://93.184.216.34/document.txt")
+
+    assert result.data == b"remote document"
+    assert result.content_type == "text/plain"
+
+
+async def test_rejects_credentials_and_non_http_protocols():
+    with pytest.raises(ValueError, match="embedded credentials"):
+        await fetch_public_url("https://user:password@example.com/file")
+    with pytest.raises(ValueError, match="file:// protocol"):
+        await fetch_public_url("file:///etc/passwd")

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Security
+
+- Hardened remote URL inputs against SSRF while preserving downloads. DNS
+  results and redirect targets must be public, connections are pinned to
+  validated addresses, and downloads enforce redirect, timeout, and size
+  limits.
+
 ## [0.1.6] - 2025-12-22
 
 ### Added

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -98,6 +98,9 @@ const result = await client.guard({
 - Uses OR logic: blocks if ANY page contains a violation
 - Text extraction only (no OCR for scanned PDFs)
 - Works with all text-capable models
+- Remote URLs must resolve exclusively to public IP addresses. Redirect targets
+  are revalidated, and downloads are limited to 5 redirects, 30 seconds, and
+  25 MiB.
 
 ### Image Support
 

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -42,11 +42,12 @@
     "vitest": "^4.0.18"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=18.17.0"
   },
   "dependencies": {
     "@daytonaio/sdk": "^0.138.0",
     "ipaddr.js": "^2.3.0",
+    "undici": "^6.28.0",
     "unpdf": "^1.4.0"
   },
   "overrides": {

--- a/sdk/typescript/src/utils/input-processor.ts
+++ b/sdk/typescript/src/utils/input-processor.ts
@@ -1,7 +1,6 @@
-import { lookup } from "node:dns/promises";
-import * as ipaddr from "ipaddr.js";
 import { getDocumentProxy } from "unpdf";
 import type { GuardInput, ProcessedInput } from "../types.js";
+import { fetchPublicUrl } from "./safe-url-fetcher.js";
 
 /**
  * Image MIME types supported by vision models
@@ -42,178 +41,6 @@ function isUrlString(input: string): boolean {
     input.startsWith("https://") ||
     input.startsWith("file://")
   );
-}
-
-/**
- * Check if an IP address is private/internal using ipaddr.js
- * Supports both IPv4 and IPv6 ranges
- */
-function isPrivateIpAddress(ip: string): boolean {
-  try {
-    const addr = ipaddr.process(ip);
-    
-    if (addr.kind() === "ipv4") {
-      const ipv4 = addr as ipaddr.IPv4;
-      
-      // Check IPv4 private ranges
-      return (
-        ipv4.range() === "private" || // 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
-        ipv4.range() === "loopback" || // 127.0.0.0/8
-        ipv4.range() === "linkLocal" || // 169.254.0.0/16
-        ipv4.range() === "multicast" // 224.0.0.0/4
-      );
-    } else if (addr.kind() === "ipv6") {
-      const ipv6 = addr as ipaddr.IPv6;
-      
-      // Check for IPv4-mapped IPv6 addresses (::ffff:127.0.0.1)
-      if (ipv6.isIPv4MappedAddress()) {
-        const ipv4Mapped = ipv6.toIPv4Address();
-        return isPrivateIpAddress(ipv4Mapped.toString());
-      }
-      
-      // Check IPv6 private ranges
-      const range = ipv6.range();
-      return (
-        range === "uniqueLocal" || // fc00::/7 (ULA)
-        range === "linkLocal" || // fe80::/10
-        range === "loopback" || // ::1
-        range === "multicast" // ff00::/8
-      );
-    }
-    
-    return false;
-  } catch {
-    // If IP parsing fails, treat as private (fail-safe)
-    return true;
-  }
-}
-
-/**
- * Check if a hostname resolves to a private/internal IP address.
- * 
- * This function performs DNS resolution to prevent SSRF attacks where
- * a hostname like "attacker.com" resolves to 127.0.0.1.
- * 
- * Blocks:
- * - IPv4: 127.0.0.0/8, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 169.254.0.0/16, 224.0.0.0/4
- * - IPv6: ::1, fc00::/7, fe80::/10, ::ffff:127.0.0.0/104, ff00::/8
- * - localhost hostnames
- * 
- * If DNS resolution fails, treats as private (fail-safe security).
- */
-async function isPrivateIp(hostname: string): Promise<boolean> {
-  const lowerHostname = hostname.toLowerCase();
-
-  // Check for localhost hostname first (common case, no DNS needed)
-  if (
-    lowerHostname === "localhost" ||
-    lowerHostname === "localhost.localdomain" ||
-    lowerHostname === "local" ||
-    lowerHostname === "127.0.0.1" ||
-    lowerHostname === "::1"
-  ) {
-    return true;
-  }
-
-  // Remove brackets from IPv6 addresses if present
-  const cleanHostname = hostname.replace(/^\[|\]$/g, "");
-
-  // Check if it's already a direct IP address (IPv4 or IPv6)
-  try {
-    // Try parsing as IP first (faster path)
-    if (ipaddr.isValid(cleanHostname)) {
-      return isPrivateIpAddress(cleanHostname);
-    }
-  } catch {
-    // Not a direct IP, continue to DNS resolution
-  }
-
-  // Perform DNS resolution to get actual IP address
-  // This prevents SSRF where hostname resolves to private IP
-  try {
-    const result = await lookup(cleanHostname, { all: false });
-    const resolvedIp = result.address;
-    
-    // Check the resolved IP address
-    return isPrivateIpAddress(resolvedIp);
-  } catch (error) {
-    // DNS resolution failed - treat as private (fail-safe)
-    // This prevents bypasses where DNS fails but might resolve to private IP
-    return true;
-  }
-}
-
-/**
- * Validate URL for security concerns.
- *
- * Throws Error with descriptive message if URL is invalid or unsafe.
- *
- * Checks:
- * - URL format is valid
- * - Protocol is http or https only
- * - Hostname is not empty
- * - No private/internal IP addresses (with DNS resolution)
- * - No localhost access
- * - No file:// protocol
- * - URL length is reasonable (max 2048 characters)
- */
-async function validateUrl(url: string): Promise<void> {
-  const MAX_URL_LENGTH = 2048;
-
-  // Check URL length
-  if (url.length > MAX_URL_LENGTH) {
-    throw new Error(
-      `Invalid URL: URL exceeds maximum length of ${MAX_URL_LENGTH} characters`
-    );
-  }
-
-  // Parse URL
-  let parsed: URL;
-  try {
-    parsed = new URL(url);
-  } catch (e) {
-    throw new Error(`Invalid URL: malformed URL format - ${String(e)}`);
-  }
-
-  // Check protocol
-  const protocol = parsed.protocol.toLowerCase();
-  if (protocol !== "http:" && protocol !== "https:") {
-    if (protocol === "file:") {
-      throw new Error("Invalid URL: file:// protocol is not allowed");
-    }
-    throw new Error(
-      `Invalid URL: protocol must be http or https, got ${protocol}`
-    );
-  }
-
-  // Check hostname
-  const hostname = parsed.hostname;
-  if (!hostname) {
-    throw new Error("Invalid URL: hostname is required");
-  }
-
-  // Check for private/internal IP addresses (with DNS resolution)
-  const lowerHostname = hostname.toLowerCase();
-  const cleanHostname = hostname.replace(/^\[|\]$/g, "");
-
-  // Check for localhost hostname patterns first (before DNS resolution)
-  if (
-    lowerHostname === "localhost" ||
-    lowerHostname === "localhost.localdomain" ||
-    lowerHostname === "local" ||
-    cleanHostname === "127.0.0.1" ||
-    cleanHostname === "::1" ||
-    cleanHostname.startsWith("127.")
-  ) {
-    throw new Error("Invalid URL: localhost access is not allowed");
-  }
-
-  const isPrivate = await isPrivateIp(hostname);
-  if (isPrivate) {
-    throw new Error(
-      "Invalid URL: private/internal IP addresses are not allowed"
-    );
-  }
 }
 
 /**
@@ -302,28 +129,18 @@ async function extractPdfPages(buffer: ArrayBuffer): Promise<string[]> {
  * Fetch content from a URL and return as ProcessedInput
  */
 async function fetchUrl(url: string): Promise<ProcessedInput> {
-  // Validate URL for security before making any network requests
-  await validateUrl(url);
-
-  const response = await fetch(url);
-
-  if (!response.ok) {
-    throw new Error(
-      `Failed to fetch URL: ${response.status} ${response.statusText}`
-    );
-  }
-
-  // Get content type from response or infer from URL
-  let contentType =
-    response.headers.get("content-type")?.split(";")[0].trim() || "";
-
-  // If no content type, try to infer from URL
+  const response = await fetchPublicUrl(url);
+  let contentType = response.contentType;
   if (!contentType) {
-    contentType = getMimeTypeFromUrl(url) || "text/plain";
+    contentType = getMimeTypeFromUrl(response.finalUrl) || "text/plain";
   }
+
+  const buffer = response.data.buffer.slice(
+    response.data.byteOffset,
+    response.data.byteOffset + response.data.byteLength
+  ) as ArrayBuffer;
 
   if (isPdfMimeType(contentType)) {
-    const buffer = await response.arrayBuffer();
     const pages = await extractPdfPages(buffer);
     return {
       type: "pdf",
@@ -333,7 +150,6 @@ async function fetchUrl(url: string): Promise<ProcessedInput> {
   }
 
   if (isImageMimeType(contentType)) {
-    const buffer = await response.arrayBuffer();
     const base64 = arrayBufferToBase64(buffer);
     return {
       type: "image",
@@ -342,8 +158,8 @@ async function fetchUrl(url: string): Promise<ProcessedInput> {
     };
   }
 
+  const text = new TextDecoder().decode(response.data);
   if (isTextMimeType(contentType)) {
-    const text = await response.text();
     return {
       type: "text",
       text,
@@ -351,18 +167,11 @@ async function fetchUrl(url: string): Promise<ProcessedInput> {
     };
   }
 
-  // For other content types, try to read as text
-  // This handles cases where server doesn't send correct content-type
-  try {
-    const text = await response.text();
-    return {
-      type: "text",
-      text,
-      mimeType: contentType,
-    };
-  } catch {
-    throw new Error(`Unsupported content type: ${contentType}`);
-  }
+  return {
+    type: "text",
+    text,
+    mimeType: contentType,
+  };
 }
 
 /**

--- a/sdk/typescript/src/utils/safe-url-fetcher.ts
+++ b/sdk/typescript/src/utils/safe-url-fetcher.ts
@@ -1,0 +1,244 @@
+import { lookup } from "node:dns/promises";
+import * as ipaddr from "ipaddr.js";
+import { Agent, fetch as undiciFetch } from "undici";
+
+const MAX_URL_LENGTH = 2048;
+const MAX_REDIRECTS = 5;
+const MAX_RESPONSE_BYTES = 25 * 1024 * 1024;
+const REQUEST_TIMEOUT_MS = 30_000;
+
+interface ResolvedAddress {
+  address: string;
+  family: 4 | 6;
+}
+
+interface ValidatedUrl {
+  parsed: URL;
+  addresses: ResolvedAddress[];
+}
+
+export interface PublicUrlResponse {
+  finalUrl: string;
+  contentType: string;
+  data: Uint8Array;
+}
+
+function isPublicIpAddress(ip: string): boolean {
+  try {
+    const address = ipaddr.process(ip);
+    if (address.kind() === "ipv6") {
+      const ipv6 = address as ipaddr.IPv6;
+      if (ipv6.isIPv4MappedAddress()) {
+        return ipv6.toIPv4Address().range() === "unicast";
+      }
+    }
+    return address.range() === "unicast";
+  } catch {
+    return false;
+  }
+}
+
+async function resolvePublicAddresses(
+  hostname: string
+): Promise<ResolvedAddress[]> {
+  const cleanHostname = hostname.replace(/^\[|\]$/g, "");
+  let addresses: ResolvedAddress[];
+
+  try {
+    if (ipaddr.isValid(cleanHostname)) {
+      const address = ipaddr.process(cleanHostname);
+      addresses = [
+        {
+          address: address.toString(),
+          family: address.kind() === "ipv4" ? 4 : 6,
+        },
+      ];
+    } else {
+      const results = await lookup(cleanHostname, {
+        all: true,
+        verbatim: true,
+      });
+      addresses = results.map(({ address, family }) => ({
+        address,
+        family: family as 4 | 6,
+      }));
+    }
+  } catch {
+    throw new Error("Invalid URL: hostname could not be resolved safely");
+  }
+
+  if (
+    addresses.length === 0 ||
+    addresses.some(({ address }) => !isPublicIpAddress(address))
+  ) {
+    throw new Error(
+      "Invalid URL: private/internal IP addresses are not allowed"
+    );
+  }
+
+  return addresses;
+}
+
+async function validateUrl(url: string): Promise<ValidatedUrl> {
+  if (url.length > MAX_URL_LENGTH) {
+    throw new Error(
+      `Invalid URL: URL exceeds maximum length of ${MAX_URL_LENGTH} characters`
+    );
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch (error) {
+    throw new Error(`Invalid URL: malformed URL format - ${String(error)}`);
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    if (parsed.protocol === "file:") {
+      throw new Error("Invalid URL: file:// protocol is not allowed");
+    }
+    throw new Error(
+      `Invalid URL: protocol must be http or https, got ${parsed.protocol}`
+    );
+  }
+
+  if (!parsed.hostname) {
+    throw new Error("Invalid URL: hostname is required");
+  }
+  if (parsed.username || parsed.password) {
+    throw new Error("Invalid URL: embedded credentials are not allowed");
+  }
+
+  const hostname = parsed.hostname.toLowerCase();
+  if (
+    hostname === "localhost" ||
+    hostname === "localhost.localdomain" ||
+    hostname === "local" ||
+    hostname === "127.0.0.1" ||
+    hostname === "::1" ||
+    hostname.startsWith("127.")
+  ) {
+    throw new Error("Invalid URL: localhost access is not allowed");
+  }
+
+  return {
+    parsed,
+    addresses: await resolvePublicAddresses(parsed.hostname),
+  };
+}
+
+function createPinnedAgent(addresses: ResolvedAddress[]): Agent {
+  let nextAddress = 0;
+  return new Agent({
+    connect: {
+      lookup: (_hostname, options, callback) => {
+        if (options.all) {
+          callback(null, addresses);
+          return;
+        }
+
+        const selected = addresses[nextAddress % addresses.length];
+        nextAddress += 1;
+        callback(null, selected.address, selected.family);
+      },
+      timeout: REQUEST_TIMEOUT_MS,
+    },
+    headersTimeout: REQUEST_TIMEOUT_MS,
+    bodyTimeout: REQUEST_TIMEOUT_MS,
+    maxResponseSize: MAX_RESPONSE_BYTES,
+  });
+}
+
+async function readResponseBody(
+  response: Awaited<ReturnType<typeof undiciFetch>>
+): Promise<Uint8Array> {
+  const declaredLength = Number(response.headers.get("content-length"));
+  if (
+    Number.isFinite(declaredLength) &&
+    declaredLength > MAX_RESPONSE_BYTES
+  ) {
+    throw new Error(
+      `Failed to fetch URL: response exceeds ${MAX_RESPONSE_BYTES} bytes`
+    );
+  }
+
+  if (!response.body) {
+    return new Uint8Array();
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalLength = 0;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    totalLength += value.byteLength;
+    if (totalLength > MAX_RESPONSE_BYTES) {
+      await reader.cancel();
+      throw new Error(
+        `Failed to fetch URL: response exceeds ${MAX_RESPONSE_BYTES} bytes`
+      );
+    }
+    chunks.push(value);
+  }
+
+  const result = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return result;
+}
+
+export async function fetchPublicUrl(url: string): Promise<PublicUrlResponse> {
+  let currentUrl = url;
+
+  for (let redirectCount = 0; redirectCount <= MAX_REDIRECTS; redirectCount++) {
+    const validated = await validateUrl(currentUrl);
+    const agent = createPinnedAgent(validated.addresses);
+
+    try {
+      const response = await undiciFetch(validated.parsed, {
+        dispatcher: agent,
+        redirect: "manual",
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      });
+
+      if (response.status >= 300 && response.status < 400) {
+        const location = response.headers.get("location");
+        await response.body?.cancel();
+        if (!location) {
+          throw new Error("Failed to fetch URL: redirect is missing Location");
+        }
+        if (redirectCount === MAX_REDIRECTS) {
+          throw new Error(
+            `Failed to fetch URL: exceeded ${MAX_REDIRECTS} redirects`
+          );
+        }
+        currentUrl = new URL(location, validated.parsed).toString();
+        continue;
+      }
+
+      if (!response.ok) {
+        await response.body?.cancel();
+        throw new Error(
+          `Failed to fetch URL: ${response.status} ${response.statusText}`
+        );
+      }
+
+      return {
+        finalUrl: currentUrl,
+        contentType:
+          response.headers.get("content-type")?.split(";")[0].trim() || "",
+        data: await readResponseBody(response),
+      };
+    } finally {
+      await agent.close();
+    }
+  }
+
+  throw new Error(`Failed to fetch URL: exceeded ${MAX_REDIRECTS} redirects`);
+}

--- a/sdk/typescript/tests/ssrf-protection.test.ts
+++ b/sdk/typescript/tests/ssrf-protection.test.ts
@@ -1,264 +1,109 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { lookup } from "node:dns/promises";
-import * as ipaddr from "ipaddr.js";
+import { fetch as undiciFetch } from "undici";
 
-// We need to test the internal functions, so we'll import the module
-// and test the validation through the public API
-import { createClient } from "../src/index.js";
+import { fetchPublicUrl } from "../src/utils/safe-url-fetcher.js";
 
-// Mock DNS lookup for testing
 vi.mock("node:dns/promises", () => ({
   lookup: vi.fn(),
 }));
 
-describe("SSRF Protection - URL Validation", () => {
-  const client = createClient();
+vi.mock("undici", () => ({
+  Agent: class {
+    async close() {}
+  },
+  fetch: vi.fn(),
+}));
 
+describe("safe URL fetching", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(undiciFetch).mockRejectedValue(new Error("fetch attempted"));
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  describe("IPv4 private IP blocking", () => {
-    it("should block localhost (127.0.0.1)", async () => {
-      await expect(
-        client.guard({
-          input: "http://127.0.0.1/test.pdf",
-          model: "openai/gpt-4o-mini",
-        })
-      ).rejects.toThrow(/localhost access is not allowed/);
-    });
-
-    it("should block 127.0.0.0/8 range", async () => {
-      await expect(
-        client.guard({
-          input: "http://127.1.2.3/test.pdf",
-          model: "openai/gpt-4o-mini",
-        })
-      ).rejects.toThrow(/localhost access is not allowed/);
-    });
-
-    it("should block localhost hostname", async () => {
-      await expect(
-        client.guard({
-          input: "http://localhost/test.pdf",
-          model: "openai/gpt-4o-mini",
-        })
-      ).rejects.toThrow(/localhost access is not allowed/);
-    });
-
-    it("should block 10.0.0.0/8 private range", async () => {
-      await expect(
-        client.guard({
-          input: "http://10.0.0.1/test.pdf",
-          model: "openai/gpt-4o-mini",
-        })
-      ).rejects.toThrow(/private\/internal IP addresses are not allowed/);
-    });
-
-    it("should block 172.16.0.0/12 private range", async () => {
-      await expect(
-        client.guard({
-          input: "http://172.16.0.1/test.pdf",
-          model: "openai/gpt-4o-mini",
-        })
-      ).rejects.toThrow(/private\/internal IP addresses are not allowed/);
-    });
-
-    it("should block 192.168.0.0/16 private range", async () => {
-      await expect(
-        client.guard({
-          input: "http://192.168.1.1/test.pdf",
-          model: "openai/gpt-4o-mini",
-        })
-      ).rejects.toThrow(/private\/internal IP addresses are not allowed/);
-    });
-
-    it("should block 169.254.0.0/16 link-local range", async () => {
-      await expect(
-        client.guard({
-          input: "http://169.254.1.1/test.pdf",
-          model: "openai/gpt-4o-mini",
-        })
-      ).rejects.toThrow(/private\/internal IP addresses are not allowed/);
-    });
+  it.each([
+    "http://127.0.0.1/admin",
+    "http://10.0.0.1/internal",
+    "http://172.16.0.1/internal",
+    "http://192.168.1.1/internal",
+    "http://169.254.169.254/latest/meta-data/",
+    "http://[::1]/admin",
+    "http://[fc00::1]/internal",
+    "http://[fe80::1]/internal",
+  ])("blocks non-public destination %s", async (url) => {
+    await expect(fetchPublicUrl(url)).rejects.toThrow(
+      /localhost access|private\/internal IP addresses/
+    );
+    expect(undiciFetch).not.toHaveBeenCalled();
   });
 
-  describe("IPv6 private IP blocking", () => {
-    it("should block IPv6 loopback (::1)", async () => {
-      await expect(
-        client.guard({
-          input: "http://[::1]/test.pdf",
-          model: "openai/gpt-4o-mini",
-        })
-      ).rejects.toThrow(/localhost access is not allowed/);
-    });
+  it("blocks hostnames when any DNS result is non-public", async () => {
+    vi.mocked(lookup).mockResolvedValue([
+      { address: "93.184.216.34", family: 4 },
+      { address: "10.0.0.1", family: 4 },
+    ] as any);
 
-    it("should block IPv6 unique local address (fc00::/7)", async () => {
-      // Mock DNS to return fc00::1
-      vi.mocked(lookup).mockResolvedValue({
-        address: "fc00::1",
-        family: 6,
-      } as any);
-
-      await expect(
-        client.guard({
-          input: "http://[fc00::1]/test.pdf",
-          model: "openai/gpt-4o-mini",
-        })
-      ).rejects.toThrow(/private\/internal IP addresses are not allowed/);
-    });
-
-    it("should block IPv6 link-local (fe80::/10)", async () => {
-      vi.mocked(lookup).mockResolvedValue({
-        address: "fe80::1",
-        family: 6,
-      } as any);
-
-      await expect(
-        client.guard({
-          input: "http://[fe80::1]/test.pdf",
-          model: "openai/gpt-4o-mini",
-        })
-      ).rejects.toThrow(/private\/internal IP addresses are not allowed/);
-    });
+    await expect(
+      fetchPublicUrl("https://mixed.example/document.pdf")
+    ).rejects.toThrow(/private\/internal IP addresses/);
+    expect(undiciFetch).not.toHaveBeenCalled();
   });
 
-  describe("DNS resolution SSRF protection", () => {
-    it("should block hostname that resolves to private IP", async () => {
-      // Mock DNS to return 127.0.0.1 for a hostname
-      vi.mocked(lookup).mockResolvedValue({
-        address: "127.0.0.1",
-        family: 4,
-      } as any);
+  it("fails closed when DNS resolution fails", async () => {
+    vi.mocked(lookup).mockRejectedValue(new Error("DNS failure"));
 
-      await expect(
-        client.guard({
-          input: "http://attacker.com/test.pdf",
-          model: "openai/gpt-4o-mini",
-        })
-      ).rejects.toThrow(/private\/internal IP addresses are not allowed/);
-    });
-
-    it("should block hostname that resolves to 10.x.x.x", async () => {
-      vi.mocked(lookup).mockResolvedValue({
-        address: "10.0.0.1",
-        family: 4,
-      } as any);
-
-      await expect(
-        client.guard({
-          input: "http://internal-service.local/test.pdf",
-          model: "openai/gpt-4o-mini",
-        })
-      ).rejects.toThrow(/private\/internal IP addresses are not allowed/);
-    });
-
-    it("should treat DNS failure as private (fail-safe)", async () => {
-      // Mock DNS to fail
-      vi.mocked(lookup).mockRejectedValue(new Error("DNS resolution failed"));
-
-      await expect(
-        client.guard({
-          input: "http://unknown-host.test/test.pdf",
-          model: "openai/gpt-4o-mini",
-        })
-      ).rejects.toThrow(/private\/internal IP addresses are not allowed/);
-    });
+    await expect(
+      fetchPublicUrl("https://unknown.example/document.pdf")
+    ).rejects.toThrow(/hostname could not be resolved safely/);
+    expect(undiciFetch).not.toHaveBeenCalled();
   });
 
-  describe("Protocol validation", () => {
-    it("should block file:// protocol", async () => {
-      await expect(
-        client.guard({
-          input: "file:///etc/passwd",
-          model: "openai/gpt-4o-mini",
-        })
-      ).rejects.toThrow(/file:\/\/ protocol is not allowed/);
-    });
+  it("validates every redirect target", async () => {
+    vi.mocked(lookup).mockResolvedValue([
+      { address: "93.184.216.34", family: 4 },
+    ] as any);
+    vi.mocked(undiciFetch).mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: { location: "http://169.254.169.254/latest/meta-data/" },
+      }) as any
+    );
 
-    it("should allow http:// protocol", async () => {
-      // This should not throw a protocol error (may fail for other reasons like DNS)
-      vi.mocked(lookup).mockResolvedValue({
-        address: "8.8.8.8",
-        family: 4,
-      } as any);
-
-      // We expect it to fail on actual fetch, not on validation
-      await expect(
-        client.guard({
-          input: "http://example.com/test.pdf",
-          model: "openai/gpt-4o-mini",
-        })
-      ).rejects.toThrow(); // May fail on fetch, but not on protocol validation
-    });
-
-    it("should allow https:// protocol", async () => {
-      vi.mocked(lookup).mockResolvedValue({
-        address: "8.8.8.8",
-        family: 4,
-      } as any);
-
-      await expect(
-        client.guard({
-          input: "https://example.com/test.pdf",
-          model: "openai/gpt-4o-mini",
-        })
-      ).rejects.toThrow(); // May fail on fetch, but not on protocol validation
-    });
+    await expect(
+      fetchPublicUrl("https://attacker.example/redirect")
+    ).rejects.toThrow(/private\/internal IP addresses/);
+    expect(undiciFetch).toHaveBeenCalledTimes(1);
   });
 
-  describe("URL length validation", () => {
-    it("should block URLs exceeding 2048 characters", async () => {
-      const longUrl = "http://example.com/" + "a".repeat(2050);
-      await expect(
-        client.guard({
-          input: longUrl,
-          model: "openai/gpt-4o-mini",
-        })
-      ).rejects.toThrow(/URL exceeds maximum length/);
-    });
+  it("continues downloading content from public URLs", async () => {
+    vi.mocked(lookup).mockResolvedValue([
+      { address: "93.184.216.34", family: 4 },
+    ] as any);
+    vi.mocked(undiciFetch).mockResolvedValueOnce(
+      new Response("remote document", {
+        status: 200,
+        headers: { "content-type": "text/plain" },
+      }) as any
+    );
+
+    const response = await fetchPublicUrl(
+      "https://example.com/document.txt"
+    );
+
+    expect(new TextDecoder().decode(response.data)).toBe("remote document");
+    expect(response.contentType).toBe("text/plain");
   });
 
-  describe("Public IP addresses", () => {
-    it("should allow public IP addresses", async () => {
-      vi.mocked(lookup).mockResolvedValue({
-        address: "8.8.8.8", // Google DNS - public IP
-        family: 4,
-      } as any);
-
-      // Should not throw validation error (may fail on actual fetch)
-      try {
-        await client.guard({
-          input: "http://8.8.8.8/test.pdf",
-          model: "openai/gpt-4o-mini",
-        });
-      } catch (error: any) {
-        // Should not be a validation error
-        expect(error.message).not.toContain("private/internal IP");
-        expect(error.message).not.toContain("localhost");
-      }
-    });
-
-    it("should allow valid public hostnames", async () => {
-      vi.mocked(lookup).mockResolvedValue({
-        address: "93.184.216.34", // example.com - public IP
-        family: 4,
-      } as any);
-
-      try {
-        await client.guard({
-          input: "http://example.com/test.pdf",
-          model: "openai/gpt-4o-mini",
-        });
-      } catch (error: any) {
-        // Should not be a validation error
-        expect(error.message).not.toContain("private/internal IP");
-        expect(error.message).not.toContain("localhost");
-      }
-    });
+  it("rejects embedded credentials and non-HTTP protocols", async () => {
+    await expect(
+      fetchPublicUrl("https://user:password@example.com/file")
+    ).rejects.toThrow(/embedded credentials/);
+    await expect(fetchPublicUrl("file:///etc/passwd")).rejects.toThrow(
+      /file:\/\/ protocol/
+    );
   });
 });


### PR DESCRIPTION
## Description
Prevent attacker-controlled guard input from triggering outbound requests by treating URL-like strings and URL objects as literal text. Remove the URL-fetching path from the TypeScript and Python SDKs, retain local Blob/byte processing, update consumer descriptions and tests, and prepare stable patch releases.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [x] Documentation update

## Testing
- TypeScript SDK: `npm test` (156 tests) and `npm run build`
- Python SDK: `uv run pytest` (126 tests)
- CLI: `npm test` (9 tests) and `npm run build`
- MCP: `npm test` (8 tests) and `npm run build`

## Checklist
- [x] Code follows project style guidelines
- [x] Tests pass locally
- [x] Documentation updated (if needed)