### PR TITLE
chore: bump patched package releases

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "safety-agent-cli",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "safety-agent-cli",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "MIT",
       "dependencies": {
-        "safety-agent": "^0.1.6"
+        "safety-agent": "^0.1.7"
       },
       "bin": {
         "superagent": "dist/index.js"
@@ -3698,17 +3698,18 @@
       "license": "MIT"
     },
     "node_modules/safety-agent": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/safety-agent/-/safety-agent-0.1.6.tgz",
-      "integrity": "sha512-MRUQVcUzFurXR4+Bapq8eGxiVc+hFpoT5LgL2vscRKCoM3BOezrR1wyh68UzGqn9C/6IOBmTUkTKsbIxzZaJwQ==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/safety-agent/-/safety-agent-0.1.7.tgz",
+      "integrity": "sha512-n0z4sRGew2aob9cm7Eb/iSZpRDCv8rqIMpFiDi7sYZ4LPmwty6yCZxFMgOmPjFyYhJlrPAxZpvveIiDl+BbZbQ==",
       "license": "MIT",
       "dependencies": {
         "@daytonaio/sdk": "^0.138.0",
         "ipaddr.js": "^2.3.0",
+        "undici": "^6.28.0",
         "unpdf": "^1.4.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=18.17.0"
       }
     },
     "node_modules/shell-quote": {
@@ -3914,6 +3915,15 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safety-agent-cli",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "CLI for Superagent - validate prompts and tool calls for security",
   "type": "module",
   "main": "./dist/index.js",
@@ -42,6 +42,6 @@
     "node": ">=18"
   },
   "dependencies": {
-    "safety-agent": "^0.1.6"
+    "safety-agent": "^0.1.7"
   }
 }

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "safety-agent-mcp",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "safety-agent-mcp",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.6.1",
-        "safety-agent": "^0.1.6",
+        "safety-agent": "^0.1.7",
         "zod": "^3.23.8"
       },
       "bin": {
@@ -4439,17 +4439,18 @@
       "license": "MIT"
     },
     "node_modules/safety-agent": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/safety-agent/-/safety-agent-0.1.6.tgz",
-      "integrity": "sha512-MRUQVcUzFurXR4+Bapq8eGxiVc+hFpoT5LgL2vscRKCoM3BOezrR1wyh68UzGqn9C/6IOBmTUkTKsbIxzZaJwQ==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/safety-agent/-/safety-agent-0.1.7.tgz",
+      "integrity": "sha512-n0z4sRGew2aob9cm7Eb/iSZpRDCv8rqIMpFiDi7sYZ4LPmwty6yCZxFMgOmPjFyYhJlrPAxZpvveIiDl+BbZbQ==",
       "license": "MIT",
       "dependencies": {
         "@daytonaio/sdk": "^0.138.0",
         "ipaddr.js": "^2.3.0",
+        "undici": "^6.28.0",
         "unpdf": "^1.4.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=18.17.0"
       }
     },
     "node_modules/safety-agent/node_modules/ipaddr.js": {
@@ -4860,6 +4861,15 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safety-agent-mcp",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "MCP server for Superagent.sh API integration - security guardrails, PII redaction, and claim verification",
   "type": "module",
   "main": "dist/index.js",
@@ -33,7 +33,7 @@
   "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.6.1",
-    "safety-agent": "^0.1.6",
+    "safety-agent": "^0.1.7",
     "zod": "^3.23.8"
   },
   "overrides": {

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "safety-agent"
-version = "0.1.7-rc2"
+version = "0.1.7"
 description = "A lightweight Python guardrail SDK for content safety"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Description
Prepare downstream releases for the SSRF-patched Safety Agent SDK: bump CLI to 0.1.7, MCP to 0.1.6, and Python SDK to stable 0.1.7. Refresh CLI and MCP lockfiles to resolve `safety-agent@0.1.7`.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- CLI: `npm test` (9 tests) and `npm run build`
- MCP: `npm test` (8 tests) and `npm run build`
- Python SDK: `uv run pytest` (152 tests)
- Inspected CLI and MCP package tarballs with `npm pack --dry-run`

## Checklist
- [x] Code follows project style guidelines
- [x] Tests pass locally
- [x] Documentation updated (if needed)