### PR TITLE
fix(sdk): honor Retry-After on 429 before falling back

### DIFF
--- a/docs/content/docs/sdk/sdk/typescript.mdx
+++ b/docs/content/docs/sdk/sdk/typescript.mdx
@@ -57,7 +57,8 @@ The SDK supports automatic fallback to an always-on endpoint when the primary Su
 const client = createClient({
   enableFallback: true,           // Enable fallback (default: true)
   fallbackTimeoutMs: 5000,        // Timeout before fallback (default: 5000ms)
-  fallbackUrl: "https://..."      // Custom fallback URL (optional)
+  fallbackUrl: "https://...",     // Custom fallback URL (optional)
+  retryAfterThresholdSeconds: 15  // Max Retry-After (s) honored before falling back
 });
 ```
 
@@ -67,6 +68,7 @@ const client = createClient({
 | `enableFallback` | `boolean` | `true` | Enable automatic fallback on timeout |
 | `fallbackTimeoutMs` | `number` | `5000` | Milliseconds to wait before falling back |
 | `fallbackUrl` | `string` | Built-in URL | Custom fallback endpoint URL |
+| `retryAfterThresholdSeconds` | `number` | `15` | Max `Retry-After` (seconds) honored on a 429 before falling back; shorter waits retry the primary model once |
 
 The fallback URL can also be set via the `SUPERAGENT_FALLBACK_URL` environment variable.
 

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -435,6 +435,7 @@ export class SafetyClient {
       enableFallback: config?.enableFallback,
       fallbackTimeoutMs: config?.fallbackTimeoutMs,
       fallbackUrl: config?.fallbackUrl,
+      retryAfterThresholdSeconds: config?.retryAfterThresholdSeconds,
     };
   }
 

--- a/sdk/typescript/src/providers/index.ts
+++ b/sdk/typescript/src/providers/index.ts
@@ -186,51 +186,15 @@ async function callProviderInternal(
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), fallbackTimeoutMs);
 
+    let response: Response;
     try {
-      const response = await fetch(url, {
+      response = await fetch(url, {
         method: "POST",
         headers,
         body: JSON.stringify(requestBody),
         signal: controller.signal,
       });
-
       clearTimeout(timeoutId);
-
-      if (!response.ok) {
-        if (
-          fallbackModelString &&
-          RETRYABLE_STATUS_CODES.includes(response.status)
-        ) {
-          const retried = await maybeRetryPrimaryAfterRetryAfter({
-            modelString,
-            messages,
-            responseFormat,
-            fallbackOptions,
-            fallbackModelString,
-            response,
-            retriedPrimaryAfterRetryAfter,
-          });
-          if (retried) {
-            return retried;
-          }
-          console.log(
-            `Primary model ${modelString} failed (${response.status}), falling back to ${fallbackModelString}`,
-          );
-          return callProvider(
-            fallbackModelString,
-            messages,
-            responseFormat,
-            fallbackOptions,
-          );
-        }
-        const errorText = await response.text();
-        throw new Error(
-          `Provider API error (${response.status}): ${errorText}`,
-        );
-      }
-
-      const responseData = await response.json();
-      return provider.transformResponse(responseData);
     } catch (error) {
       clearTimeout(timeoutId);
 
@@ -270,6 +234,47 @@ async function callProviderInternal(
       // Re-throw non-timeout errors
       throw error;
     }
+
+    // Response handling lives OUTSIDE the timeout catch: once a response has
+    // arrived the cold-start timeout concern is over, and a rejection from the
+    // Retry-After retry chain (or the fallback-model call) must not be
+    // misrouted to the always-on URL by the abort/timeout message heuristic
+    // above, which would mask the real provider error.
+    if (!response.ok) {
+      if (
+        fallbackModelString &&
+        RETRYABLE_STATUS_CODES.includes(response.status)
+      ) {
+        const retried = await maybeRetryPrimaryAfterRetryAfter({
+          modelString,
+          messages,
+          responseFormat,
+          fallbackOptions,
+          fallbackModelString,
+          response,
+          retriedPrimaryAfterRetryAfter,
+        });
+        if (retried) {
+          return retried;
+        }
+        console.log(
+          `Primary model ${modelString} failed (${response.status}), falling back to ${fallbackModelString}`,
+        );
+        return callProvider(
+          fallbackModelString,
+          messages,
+          responseFormat,
+          fallbackOptions,
+        );
+      }
+      const errorText = await response.text();
+      throw new Error(
+        `Provider API error (${response.status}): ${errorText}`,
+      );
+    }
+
+    const responseData = await response.json();
+    return provider.transformResponse(responseData);
   }
 
   // No fallback - standard request

--- a/sdk/typescript/src/providers/index.ts
+++ b/sdk/typescript/src/providers/index.ts
@@ -26,6 +26,30 @@ export interface FallbackOptions {
   fallbackTimeoutMs?: number;
   /** Custom fallback URL. If not provided, uses env var or default */
   fallbackUrl?: string;
+  /**
+   * Upper bound (in seconds) for honoring a provider-declared `Retry-After` on a 429.
+   * Waits shorter than this are slept through and the primary model is retried once,
+   * instead of instantly burning the fallback on the same rate-limit burst. Longer or
+   * missing `Retry-After` values preserve the current fallback behavior. Default: 15.
+   */
+  retryAfterThresholdSeconds?: number;
+}
+
+const DEFAULT_RETRY_AFTER_THRESHOLD_SECONDS = 15;
+
+function parseRetryAfterSeconds(header: string | null): number | null {
+  if (!header) {
+    return null;
+  }
+  const seconds = Number.parseInt(header, 10);
+  if (Number.isNaN(seconds) || seconds < 0) {
+    return null;
+  }
+  return seconds;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 /**
@@ -104,6 +128,24 @@ export async function callProvider(
   fallbackOptions?: FallbackOptions,
   fallbackModelString?: string,
 ): Promise<AnalysisResponse> {
+  return callProviderInternal(
+    modelString,
+    messages,
+    responseFormat,
+    fallbackOptions,
+    fallbackModelString,
+    false,
+  );
+}
+
+async function callProviderInternal(
+  modelString: string,
+  messages: ChatMessage[],
+  responseFormat?: ResponseFormat,
+  fallbackOptions?: FallbackOptions,
+  fallbackModelString?: string,
+  retriedPrimaryAfterRetryAfter = false,
+): Promise<AnalysisResponse> {
   const { provider: providerName, model } = parseModel(modelString);
   const provider = getProvider(providerName);
 
@@ -159,6 +201,18 @@ export async function callProvider(
           fallbackModelString &&
           RETRYABLE_STATUS_CODES.includes(response.status)
         ) {
+          const retried = await maybeRetryPrimaryAfterRetryAfter({
+            modelString,
+            messages,
+            responseFormat,
+            fallbackOptions,
+            fallbackModelString,
+            response,
+            retriedPrimaryAfterRetryAfter,
+          });
+          if (retried) {
+            return retried;
+          }
           console.log(
             `Primary model ${modelString} failed (${response.status}), falling back to ${fallbackModelString}`,
           );
@@ -230,6 +284,18 @@ export async function callProvider(
       fallbackModelString &&
       RETRYABLE_STATUS_CODES.includes(response.status)
     ) {
+      const retried = await maybeRetryPrimaryAfterRetryAfter({
+        modelString,
+        messages,
+        responseFormat,
+        fallbackOptions,
+        fallbackModelString,
+        response,
+        retriedPrimaryAfterRetryAfter,
+      });
+      if (retried) {
+        return retried;
+      }
       console.log(
         `Primary model ${modelString} failed (${response.status}), falling back to ${fallbackModelString}`,
       );
@@ -246,6 +312,62 @@ export async function callProvider(
 
   const responseData = await response.json();
   return provider.transformResponse(responseData);
+}
+
+/**
+ * On a 429 with a short, valid `Retry-After`, wait out the cooldown and retry
+ * the primary model once instead of instantly burning the fallback on the same
+ * rate-limit burst. Returns the retried response when handled; `null` when the
+ * caller should proceed with its normal fallback path (no/missing/long/weird
+ * `Retry-After`, or a retry already happened this call chain).
+ */
+async function maybeRetryPrimaryAfterRetryAfter(params: {
+  modelString: string;
+  messages: ChatMessage[];
+  responseFormat?: ResponseFormat;
+  fallbackOptions?: FallbackOptions;
+  fallbackModelString?: string;
+  response: Response;
+  retriedPrimaryAfterRetryAfter: boolean;
+}): Promise<AnalysisResponse | null> {
+  const {
+    modelString,
+    messages,
+    responseFormat,
+    fallbackOptions,
+    fallbackModelString,
+    response,
+    retriedPrimaryAfterRetryAfter,
+  } = params;
+
+  if (response.status !== 429 || retriedPrimaryAfterRetryAfter) {
+    return null;
+  }
+
+  const retryAfterSeconds = parseRetryAfterSeconds(
+    response.headers?.get("retry-after") ?? null,
+  );
+  const thresholdSeconds =
+    fallbackOptions?.retryAfterThresholdSeconds ??
+    DEFAULT_RETRY_AFTER_THRESHOLD_SECONDS;
+
+  if (retryAfterSeconds === null || retryAfterSeconds > thresholdSeconds) {
+    return null;
+  }
+
+  console.log(
+    `Primary model ${modelString} rate-limited (429), retrying after ${retryAfterSeconds}s (Retry-After)`,
+  );
+  await sleep(retryAfterSeconds * 1000);
+
+  return callProviderInternal(
+    modelString,
+    messages,
+    responseFormat,
+    fallbackOptions,
+    fallbackModelString,
+    true,
+  );
 }
 
 export type { ProviderConfig, ResponseFormat, JsonSchema } from "./types.js";

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -10,6 +10,13 @@ export interface ClientConfig {
   fallbackTimeoutMs?: number;
   /** Custom fallback URL. If not provided, uses SUPERAGENT_FALLBACK_URL env var or built-in default */
   fallbackUrl?: string;
+  /**
+   * Upper bound (in seconds) for honoring a provider-declared `Retry-After` on
+   * a 429 before falling back. Waits shorter than this are slept through and
+   * the primary model is retried once; longer or missing values preserve the
+   * current fallback behavior. Default: 15.
+   */
+  retryAfterThresholdSeconds?: number;
 }
 
 /**

--- a/sdk/typescript/tests/fallback.test.ts
+++ b/sdk/typescript/tests/fallback.test.ts
@@ -81,12 +81,30 @@ describe("Client Fallback Options", () => {
         enableFallback: true,
         fallbackTimeoutMs: 3000,
         fallbackUrl: "https://custom.example.com/api/chat",
+        retryAfterThresholdSeconds: 30,
       };
       // Verify config shape is valid
       expect(config.enableFallback).toBe(true);
       expect(config.fallbackTimeoutMs).toBe(3000);
       expect(config.fallbackUrl).toBe("https://custom.example.com/api/chat");
+      expect(config.retryAfterThresholdSeconds).toBe(30);
     }).not.toThrow();
+  });
+
+  it("should pass retryAfterThresholdSeconds from ClientConfig into SafetyClient fallbackOptions", async () => {
+    // Regression: the threshold was only on FallbackOptions and never wired
+    // through ClientConfig / SafetyClient, so createClient users could not
+    // configure it despite the docs.
+    const { createClient } = await import("../src/index.js");
+    const client = createClient({
+      apiKey: "test-key",
+      retryAfterThresholdSeconds: 30,
+    });
+
+    const fallbackOptions = (client as unknown as {
+      fallbackOptions: { retryAfterThresholdSeconds?: number };
+    }).fallbackOptions;
+    expect(fallbackOptions.retryAfterThresholdSeconds).toBe(30);
   });
 });
 

--- a/sdk/typescript/tests/model-fallback.test.ts
+++ b/sdk/typescript/tests/model-fallback.test.ts
@@ -33,6 +33,19 @@ function errorResponse(status: number, message: string) {
   );
 }
 
+function retryAfterResponse(status: number, message: string, retryAfterSeconds: number) {
+  return new Response(
+    JSON.stringify({ error: { code: status, message, status: "RATE_LIMITED" } }),
+    {
+      status,
+      headers: {
+        "Content-Type": "application/json",
+        "Retry-After": String(retryAfterSeconds),
+      },
+    },
+  );
+}
+
 describe("Model Fallback", () => {
   const originalEnv = process.env;
 
@@ -233,5 +246,88 @@ describe("Model Fallback", () => {
 
     expect(result.choices[0].message.content).toContain("pass");
     expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("should wait Retry-After and retry the primary model on short 429", async () => {
+    vi.useFakeTimers();
+    const sleepSpy = vi.spyOn(globalThis, "setTimeout");
+    const fetchSpy = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(retryAfterResponse(429, "Rate limited", 2))
+      .mockResolvedValueOnce(jsonResponse(googleSuccessResponse()));
+
+    const promise = callProvider(
+      "google/gemini-2.5-flash-lite",
+      [{ role: "user", content: "test" }],
+      undefined,
+      undefined,
+      "google/gemini-2.5-pro",
+    );
+
+    // Advance the fake clock past the Retry-After sleep so the retry proceeds.
+    await vi.advanceTimersByTimeAsync(2000);
+    const result = await promise;
+
+    expect(result.choices[0].message.content).toContain("pass");
+    // Primary -> sleep -> primary again; no fallback involved.
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    const firstUrl = fetchSpy.mock.calls[0][0] as string;
+    const secondUrl = fetchSpy.mock.calls[1][0] as string;
+    expect(firstUrl).toContain("gemini-2.5-flash-lite");
+    expect(secondUrl).toContain("gemini-2.5-flash-lite");
+    expect(sleepSpy).toHaveBeenCalled();
+
+    vi.useRealTimers();
+  });
+
+  it("should fall back when Retry-After exceeds the threshold", async () => {
+    vi.useFakeTimers();
+    const fetchSpy = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(retryAfterResponse(429, "Rate limited", 60))
+      .mockResolvedValueOnce(jsonResponse(googleSuccessResponse()));
+
+    const promise = callProvider(
+      "google/gemini-2.5-flash-lite",
+      [{ role: "user", content: "test" }],
+      undefined,
+      undefined,
+      "google/gemini-2.5-pro",
+    );
+
+    await vi.advanceTimersByTimeAsync(0);
+    const result = await promise;
+
+    expect(result.choices[0].message.content).toContain("pass");
+    // No sleep: falls straight through to the fallback model.
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    const secondUrl = fetchSpy.mock.calls[1][0] as string;
+    expect(secondUrl).toContain("gemini-2.5-pro");
+
+    vi.useRealTimers();
+  });
+
+  it("should fall back when Retry-After is missing on a 429", async () => {
+    vi.useFakeTimers();
+    const fetchSpy = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(errorResponse(429, "Rate limited"))
+      .mockResolvedValueOnce(jsonResponse(googleSuccessResponse()));
+
+    const promise = callProvider(
+      "google/gemini-2.5-flash-lite",
+      [{ role: "user", content: "test" }],
+      undefined,
+      undefined,
+      "google/gemini-2.5-pro",
+    );
+
+    await vi.advanceTimersByTimeAsync(0);
+    const result = await promise;
+
+    expect(result.choices[0].message.content).toContain("pass");
+    // Existing behavior preserved: instant fallback, no wait.
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    const secondUrl = fetchSpy.mock.calls[1][0] as string;
+    expect(secondUrl).toContain("gemini-2.5-pro");
+
+    vi.useRealTimers();
   });
 });

--- a/sdk/typescript/tests/model-fallback.test.ts
+++ b/sdk/typescript/tests/model-fallback.test.ts
@@ -330,4 +330,49 @@ describe("Model Fallback", () => {
 
     vi.useRealTimers();
   });
+
+  it("should not misroute a retry-chain failure to the always-on URL when its message mentions timeout", async () => {
+    // Regression: the Retry-After retry chain used to sit inside the cold-start
+    // try/catch, so a failure from the retried primary whose message happened to
+    // contain "timeout" was swallowed by the abort/timeout heuristic and the
+    // real provider error was masked by an always-on fallback call. Response
+    // handling now lives outside the timeout catch.
+    vi.useFakeTimers();
+    const fetchSpy = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(retryAfterResponse(429, "Rate limited", 2))
+      .mockResolvedValueOnce(
+        // A NON-retryable failure whose body happens to mention "timeout": in
+        // the buggy layout this was swallowed by the outer cold-start timeout
+        // heuristic and swapped for an always-on fallback response.
+        errorResponse(400, "Bad request mentioning timeout"),
+      )
+      // Safety net: if the always-on URL is (wrongly) hit, give it a plausible
+      // response so the misrouting is visible via the reject/call-count asserts.
+      .mockResolvedValue(jsonResponse(googleSuccessResponse()));
+
+    const promise = callProvider(
+      "superagent/guard-1.7b",
+      [{ role: "user", content: "test" }],
+      undefined,
+      { enableFallback: true },
+      "superagent/guard-1.7b",
+    );
+
+    // Attach the rejection handler BEFORE advancing the clock so the retried
+    // call's rejection is observed (not reported as an unhandled rejection).
+    const assertion = expect(promise).rejects.toThrow(
+      /Provider API error \(400\)/,
+    );
+    // Advance past the Retry-After sleep so the retried primary call runs.
+    await vi.advanceTimersByTimeAsync(2000);
+
+    // The real 400 error propagates; it is NOT swapped for a fallback response.
+    await assertion;
+    // Primary 429 -> retried primary 400. No always-on fallback fetch.
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    const urls = fetchSpy.mock.calls.map((call) => call[0] as string);
+    expect(urls.some((u) => u.includes("/fallback"))).toBe(false);
+
+    vi.useRealTimers();
+  });
 });


### PR DESCRIPTION
Closes #1145

## Problem

`callProvider()` treats a 429 as an instant-fallback trigger. Under concurrent load, the same burst that rate-limited the primary model immediately hits the fallback — both models end up rate-limited. A 429 with a provider-declared `Retry-After` is a WAIT signal, not an "abandon this model" signal.

## Fix

On a 429, parse the `Retry-After` header as delay-seconds:

- **Present, valid, and below the threshold** — sleep the declared duration, then retry the **primary** model once (never an instant fallback burn).
- **Missing, malformed, or above the threshold** — preserve the existing fallback behavior unchanged.
- **One retry max per call chain** — a second 429 during the retry goes straight to the normal fallback path (no blocking retry loop).

The threshold is configurable via the new `FallbackOptions.retryAfterThresholdSeconds` option (default 15s).

## Tests

Three new cases in `model-fallback.test.ts`:
- 429 with a short `Retry-After` → waits, retries the primary (2 calls to the primary, no fallback)
- 429 with `Retry-After` above the threshold → falls back immediately
- 429 with no `Retry-After` → falls back immediately (existing behavior locked in)

All 165 SDK tests pass; `tsc` build clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes retry/fallback timing for all guard/redact paths that use model fallback; bounded wait (default ≤15s) and one retry limit risk but can add latency under rate limits.
> 
> **Overview**
> **`callProvider`** no longer treats every **429** as an instant trigger to the fallback model. When the primary returns **429** with a valid **`Retry-After`** shorter than a threshold (default **15s**, via new **`FallbackOptions.retryAfterThresholdSeconds`**), the SDK **sleeps** that duration and **retries the primary once** instead of immediately hitting the fallback on the same burst.
> 
> If **`Retry-After`** is missing, invalid, or above the threshold—or a retry already happened in that call chain—behavior stays the same: fall back to **`fallbackModelString`** for retryable errors (**429**, **500**, **502**, **503**).
> 
> Implementation adds **`callProviderInternal`** with a **`retriedPrimaryAfterRetryAfter`** flag and **`maybeRetryPrimaryAfterRetryAfter`**, wired on both the superagent timeout path and the standard fetch path. **`model-fallback.test.ts`** adds cases for short wait + primary retry, long **`Retry-After`**, and missing header.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7abaee410f37edef3f16fbfab01c931bf998e875. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->